### PR TITLE
Add dynamic workflow fan-out primitives

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added workflow `foreach` dynamic fan-out and child `.omhflow` invocation primitives with collapsed graph metadata, checkpointable item lifecycle output, and examples. ([#2](https://github.com/humanfia/oh-my-humanize/issues/2))
+
 ### Changed
 
 - Changed public branding from Oh My Pi / `omp` to Oh My Humanize / `omh` across package metadata, CLI help, ACP metadata, setup/welcome surfaces, workflow docs, and README examples while preserving `omp` as a compatibility bin alias.

--- a/packages/coding-agent/examples/workflows/dynamic-fanout/foreach-child-worker.omhflow
+++ b/packages/coding-agent/examples/workflows/dynamic-fanout/foreach-child-worker.omhflow
@@ -1,0 +1,22 @@
+---
+name: foreach-child-worker
+version: 1
+schema: omhflow/v1
+checkpoint:
+  stopDeadlineMs: 30000
+changePolicy:
+  agentsCanPropose: false
+  humansCanApprove: true
+---
+# Foreach Child Worker
+
+```yaml workflow
+nodes:
+  handleTask:
+    type: script
+    script:
+      language: js
+      inline: |
+        return { summary: "child workflow handled task" };
+edges: []
+```

--- a/packages/coding-agent/examples/workflows/dynamic-fanout/foreach-child-workflow.omhflow
+++ b/packages/coding-agent/examples/workflows/dynamic-fanout/foreach-child-workflow.omhflow
@@ -1,0 +1,30 @@
+---
+name: foreach-child-workflow
+version: 1
+schema: omhflow/v1
+checkpoint:
+  stopDeadlineMs: 30000
+changePolicy:
+  agentsCanPropose: false
+  humansCanApprove: true
+---
+# Foreach Child Workflow
+
+```yaml workflow
+stateSchema:
+  version: 1
+  shape:
+    tasks: array
+    childRuns: object
+foreach:
+  id: runChildForTasks
+  items: /tasks
+  key: /id
+  concurrency: 2
+  failureMode: allSettled
+  output:
+    path: /childRuns
+  body:
+    workflow:
+      path: ./foreach-child-worker.omhflow
+```

--- a/packages/coding-agent/examples/workflows/dynamic-fanout/minimal-foreach.omhflow
+++ b/packages/coding-agent/examples/workflows/dynamic-fanout/minimal-foreach.omhflow
@@ -1,0 +1,40 @@
+---
+name: minimal-foreach
+version: 1
+schema: omhflow/v1
+checkpoint:
+  stopDeadlineMs: 30000
+changePolicy:
+  agentsCanPropose: false
+  humansCanApprove: true
+---
+# Minimal Foreach
+
+```yaml workflow
+stateSchema:
+  version: 1
+  shape:
+    tasks: array
+    taskResults: object
+foreach:
+  id: processTasks
+  items: /tasks
+  itemName: task
+  key: /id
+  concurrency: 2
+  failureMode: allSettled
+  output:
+    path: /taskResults
+  body:
+    node:
+      id: processTask
+      type: script
+      script:
+        language: js
+        inline: |
+          const task = context.state.task;
+          return {
+            summary: `processed ${task.id}`,
+            data: { id: task.id, status: "done" },
+          };
+```

--- a/packages/coding-agent/src/cli/__tests__/workflow-cli.test.ts
+++ b/packages/coding-agent/src/cli/__tests__/workflow-cli.test.ts
@@ -175,6 +175,46 @@ describe("workflow CLI", () => {
 		expect(result.runs[0]?.stateKeys).toEqual(["marker"]);
 	});
 
+	it("runs headless child workflow nodes as linked child families", async () => {
+		using tempDir = TempDir.createSync("@omp-workflow-cli-child-workflow-");
+		const root = tempDir.path();
+		await Bun.write(`${root}/parent.omhflow`, workflowParentChildFlow());
+		await Bun.write(`${root}/parent/.keep`, "");
+		await Bun.write(`${root}/child/.keep`, "");
+		await Bun.write(`${root}/child.omhflow`, workflowChildFlow());
+		const output: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			output.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+			return true;
+		});
+
+		await runWorkflowCommand({
+			action: "start",
+			args: [`${root}/parent.omhflow`],
+			flags: {
+				cwd: root,
+				json: true,
+				runId: "parent-child-run",
+				familyId: "parent-child-family",
+			},
+		});
+
+		const result = JSON.parse(output.join("").trim()) as {
+			run: { status: string; completed: number; failed: number };
+			families: { id: string; attempts: { status: string }[] }[];
+			runs: { id: string; stateKeys: string[] }[];
+		};
+		expect(result.run).toMatchObject({ status: "completed", completed: 1, failed: 0 });
+		expect(result.families.map(family => [family.id, family.attempts[0]?.status])).toEqual([
+			["parent-child-family", "completed"],
+			["activation-1:child:invokeChild:family", "completed"],
+		]);
+		expect(result.runs.map(run => [run.id, run.stateKeys])).toEqual([
+			["parent-child-run", ["childResult"]],
+			["activation-1:child:invokeChild", ["childMessage"]],
+		]);
+	});
+
 	it("checkpoints headless workflow starts on SIGINT instead of leaving a run alive", async () => {
 		using tempDir = TempDir.createSync("@omp-workflow-cli-sigint-");
 		const root = tempDir.path();
@@ -383,6 +423,79 @@ function workflowJsCwdSmokeScript(): string {
 		'  summary: "cwd marker observed",',
 		'  statePatch: [{ op: "set", path: "/marker", value: marker }],',
 		"};",
+	].join("\n");
+}
+
+function workflowParentChildFlow(): string {
+	return [
+		"---",
+		"name: parent-child",
+		"version: 1",
+		"schema: omhflow/v1",
+		"resourceDir: parent-child",
+		"models:",
+		"  roles: {}",
+		"  defaults: {}",
+		"checkpoint:",
+		"  stopDeadlineMs: 30000",
+		"changePolicy:",
+		"  agentsCanPropose: true",
+		"  humansCanApprove: true",
+		"---",
+		"# Parent child workflow",
+		"",
+		"```yaml workflow",
+		"stateSchema:",
+		"  version: 1",
+		"  shape:",
+		"    childResult: object",
+		"nodes:",
+		"  invokeChild:",
+		"    type: workflow",
+		"    workflow:",
+		"      path: ./child.omhflow",
+		"    writes:",
+		"      - /childResult",
+		"edges: []",
+		"```",
+	].join("\n");
+}
+
+function workflowChildFlow(): string {
+	return [
+		"---",
+		"name: child",
+		"version: 1",
+		"schema: omhflow/v1",
+		"resourceDir: child",
+		"models:",
+		"  roles: {}",
+		"  defaults: {}",
+		"checkpoint:",
+		"  stopDeadlineMs: 30000",
+		"changePolicy:",
+		"  agentsCanPropose: true",
+		"  humansCanApprove: true",
+		"---",
+		"# Child workflow",
+		"",
+		"```yaml workflow",
+		"stateSchema:",
+		"  version: 1",
+		"  shape:",
+		"    childMessage: string",
+		"nodes:",
+		"  writeMessage:",
+		"    type: script",
+		"    script:",
+		"      language: js",
+		"      inline: |",
+		"        return {",
+		'          summary: "child completed",',
+		'          statePatch: [{ op: "set", path: "/childMessage", value: "ok" }],',
+		"        };",
+		"edges: []",
+		"```",
 	].join("\n");
 }
 

--- a/packages/coding-agent/src/cli/workflow-cli.ts
+++ b/packages/coding-agent/src/cli/workflow-cli.ts
@@ -13,6 +13,7 @@ import type { WorkflowDefinition } from "../workflow/definition";
 import { type FlowFreeze, freezeWorkflowArtifact } from "../workflow/freeze";
 import type { RuntimeBindingSnapshot } from "../workflow/lifecycle";
 import { reconstructWorkflowFamilies } from "../workflow/lifecycle";
+import type { WorkflowWorkflowNodeOutput } from "../workflow/node-runtime";
 import { loadWorkflowArtifact, WorkflowPackageError } from "../workflow/package-loader";
 import { reconstructWorkflowRuns, type WorkflowRunStoreHost } from "../workflow/run-store";
 import { runWorkflow } from "../workflow/runner";
@@ -22,6 +23,7 @@ import { workflowScriptEnvironment } from "../workflow/script-runtime-env";
 import {
 	createSessionWorkflowRuntimeHost,
 	type WorkflowAgentTaskRequest,
+	type WorkflowChildWorkflowRequest,
 	type WorkflowShellScriptRequest,
 } from "../workflow/session-runtime";
 
@@ -200,6 +202,7 @@ async function handleStart(command: WorkflowCommandArgs, runtime: WorkflowComman
 	const runtimeHost = createSessionWorkflowRuntimeHost({
 		cwd,
 		runEvalScript: async request => runHeadlessEvalScript(cwd, request.code, request.language),
+		runChildWorkflow: async request => runHeadlessChildWorkflow(cwd, host, request),
 		runShellScript: async request => runHeadlessShellScript(cwd, request),
 		runAgentTask: async request => runHeadlessAgentTask(cwd, request),
 	});
@@ -389,10 +392,8 @@ function createHeadlessRuntimeBindingSnapshot(
 	const tools = new Set<string>();
 	const agents = new Set<string>();
 	for (const node of definition.nodes) {
-		if (node.type === "script") tools.add(node.script?.language === "sh" ? "bash" : "eval");
-		if (node.type === "human") tools.add("ask");
-		if (node.type === "agent" || node.type === "review") tools.add("task");
-		if (node.agent) agents.add(node.agent);
+		for (const tool of headlessRuntimeBindingToolsForNode(node)) tools.add(tool);
+		for (const agent of headlessRuntimeBindingAgentsForNode(node)) agents.add(agent);
 	}
 	for (const tool of definition.capabilities?.tools ?? []) tools.add(tool);
 	for (const agent of definition.capabilities?.agents ?? []) agents.add(agent);
@@ -412,6 +413,100 @@ function createHeadlessRuntimeBindingSnapshot(
 			? ["headless workflow CLI cannot answer human nodes; use interactive /workflow start for those flows"]
 			: [],
 	};
+}
+
+function headlessRuntimeBindingToolsForNode(node: WorkflowStartPackage["definition"]["nodes"][number]): string[] {
+	if (node.type === "script") return [node.script?.language === "sh" ? "bash" : "eval"];
+	if (node.type === "human") return ["ask"];
+	if (node.type === "agent" || node.type === "review") return ["task"];
+	if (node.type === "workflow") return ["workflow"];
+	if (node.type === "foreach") {
+		if (node.foreach?.body.kind === "workflow") return ["workflow"];
+		if (node.foreach?.body.kind === "node") return headlessRuntimeBindingToolsForNode(node.foreach.body.node);
+	}
+	return [];
+}
+
+function headlessRuntimeBindingAgentsForNode(node: WorkflowStartPackage["definition"]["nodes"][number]): string[] {
+	if (node.agent) return [node.agent];
+	if (node.type === "foreach" && node.foreach?.body.kind === "node") {
+		return headlessRuntimeBindingAgentsForNode(node.foreach.body.node);
+	}
+	return [];
+}
+
+async function runHeadlessChildWorkflow(
+	cwd: string,
+	host: WorkflowRunStoreHost,
+	request: WorkflowChildWorkflowRequest,
+): Promise<WorkflowWorkflowNodeOutput> {
+	const childPath = resolveHeadlessChildWorkflowPath(cwd, request);
+	const pkg = await loadWorkflowStartPackage(childPath);
+	if (pkg.freeze === undefined) {
+		throw new Error(`Child workflow "${request.workflowPath}" must be a frozen .omhflow artifact`);
+	}
+	const startNodeIds = defaultWorkflowStartNodeIds(pkg.definition);
+	const startNodeId = startNodeIds[0];
+	if (!startNodeId) throw new Error(`Child workflow "${request.workflowPath}" has no start node`);
+	const runId = `${request.activationId}:child:${safeWorkflowIdPart(request.itemKey ?? request.nodeId)}`;
+	const familyId = `${runId}:family`;
+	const attemptId = `${runId}:attempt-1`;
+	const runtimeHost = createSessionWorkflowRuntimeHost({
+		cwd,
+		runEvalScript: async childRequest => runHeadlessEvalScript(cwd, childRequest.code, childRequest.language),
+		runChildWorkflow: async childRequest => runHeadlessChildWorkflow(cwd, host, childRequest),
+		runShellScript: async childRequest => runHeadlessShellScript(cwd, childRequest),
+		runAgentTask: async childRequest => runHeadlessAgentTask(cwd, childRequest),
+	});
+	const runtimeBindingSnapshot = createHeadlessRuntimeBindingSnapshot(pkg.definition, `${runId}:binding-1`);
+	const bindingError = workflowRuntimeBindingUnavailableError(runtimeBindingSnapshot, pkg.definition, startNodeIds);
+	if (bindingError !== undefined) throw new Error(bindingError);
+	const result = await runWorkflow({
+		host,
+		definition: pkg.definition,
+		runId,
+		startNodeId,
+		...(startNodeIds.length > 1 ? { startNodeIds } : {}),
+		runtimeHost,
+		packageRoot: pkg.rootPath,
+		initialState: structuredClone(request.state),
+		...(pkg.freeze !== undefined ? { frozenResources: pkg.freeze.resourceSnapshots } : {}),
+		signal: request.signal,
+		nodeAbortSignal: request.signal,
+		maxRuntimeMs: DEFAULT_WORKFLOW_MAX_RUNTIME_MS,
+		lifecycle: {
+			familyId,
+			attemptId,
+			freeze: pkg.freeze,
+			runtimeBindingSnapshot,
+		},
+	});
+	const failed = result.scheduler.activations.find(activation => activation.status === "failed");
+	if (failed !== undefined) {
+		throw new Error(`Child workflow "${request.workflowPath}" failed at node "${failed.nodeId}": ${failed.error}`);
+	}
+	const completed = result.scheduler.activations.filter(activation => activation.status === "completed");
+	return {
+		summary: completed.at(-1)?.output?.summary ?? `child workflow "${request.workflowPath}" completed`,
+		data: {
+			status: result.scheduler.limitReached ? "stopped" : "completed",
+			state: structuredClone(result.scheduler.state),
+		},
+		childFamilyId: familyId,
+		childAttemptId: attemptId,
+	};
+}
+
+function resolveHeadlessChildWorkflowPath(cwd: string, request: WorkflowChildWorkflowRequest): string {
+	if (path.isAbsolute(request.workflowPath)) return request.workflowPath;
+	if (request.workflowBasePath !== undefined) {
+		return path.resolve(path.dirname(request.workflowBasePath), request.workflowPath);
+	}
+	return path.resolve(cwd, request.workflowPath);
+}
+
+function safeWorkflowIdPart(value: string): string {
+	return value.replace(/[^A-Za-z0-9_.:-]+/gu, "-");
 }
 
 async function runHeadlessEvalScript(

--- a/packages/coding-agent/src/slash-commands/helpers/workflow.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/workflow.ts
@@ -1700,10 +1700,8 @@ async function createRuntimeBindingSnapshot(
 		skills: (definition.capabilities?.skills?.length ?? 0) > 0,
 	});
 	for (const node of definition.nodes) {
-		if (node.type === "script") tools.add(runtimeBindingScriptToolForNode(node));
-		if (node.type === "human") tools.add("ask");
-		if (node.type === "agent" || node.type === "review") tools.add("task");
-		if (node.agent) agents.add(node.agent);
+		for (const tool of runtimeBindingToolsForNode(node)) tools.add(tool);
+		for (const agent of runtimeBindingAgentsForNode(node)) agents.add(agent);
 		recordRuntimeBindingTool(node, runtimeHost, unavailable);
 		recordRuntimeBindingModel(definition, node, modelResolution, modelBindings);
 	}
@@ -1831,6 +1829,26 @@ function collectSkillCapabilities(runtime: SlashCommandRuntime): Set<string> {
 	return new Set((runtime.session.skills ?? []).map(skill => skill.name));
 }
 
+function runtimeBindingToolsForNode(node: WorkflowNode): string[] {
+	if (node.type === "script") return [runtimeBindingScriptToolForNode(node)];
+	if (node.type === "human") return ["ask"];
+	if (node.type === "agent" || node.type === "review") return ["task"];
+	if (node.type === "workflow") return ["workflow"];
+	if (node.type === "foreach") {
+		if (node.foreach?.body.kind === "workflow") return ["workflow"];
+		if (node.foreach?.body.kind === "node") return runtimeBindingToolsForNode(node.foreach.body.node);
+	}
+	return [];
+}
+
+function runtimeBindingAgentsForNode(node: WorkflowNode): string[] {
+	if (node.agent) return [node.agent];
+	if (node.type === "foreach" && node.foreach?.body.kind === "node") {
+		return runtimeBindingAgentsForNode(node.foreach.body.node);
+	}
+	return [];
+}
+
 function recordRuntimeBindingTool(
 	node: WorkflowNode,
 	runtimeHost: WorkflowNodeRuntimeHost,
@@ -1850,6 +1868,16 @@ function recordRuntimeBindingTool(
 	if (node.type === "review" && runtimeHost.runReviewNode === undefined) {
 		pushUnique(unavailable, "tool:task: workflow runtime host does not support review nodes");
 	}
+	if (node.type === "workflow" && runtimeHost.runWorkflowNode === undefined) {
+		pushUnique(unavailable, "tool:workflow: workflow runtime host does not support child workflow nodes");
+	}
+	if (node.type === "foreach") {
+		if (node.foreach?.body.kind === "workflow" && runtimeHost.runWorkflowNode === undefined) {
+			pushUnique(unavailable, "tool:workflow: workflow runtime host does not support child workflow nodes");
+		}
+		if (node.foreach?.body.kind === "node")
+			recordRuntimeBindingTool(node.foreach.body.node, runtimeHost, unavailable);
+	}
 }
 
 function recordRuntimeBindingDeclaredTool(
@@ -1867,6 +1895,12 @@ function recordRuntimeBindingDeclaredTool(
 	if (tool === "ask") {
 		if (runtimeHost.runHumanNode === undefined) {
 			pushUnique(unavailable, "tool:ask: workflow runtime host does not support human nodes");
+		}
+		return;
+	}
+	if (tool === "workflow") {
+		if (runtimeHost.runWorkflowNode === undefined) {
+			pushUnique(unavailable, "tool:workflow: workflow runtime host does not support child workflow nodes");
 		}
 		return;
 	}

--- a/packages/coding-agent/src/workflow/change-request-file.ts
+++ b/packages/coding-agent/src/workflow/change-request-file.ts
@@ -1,5 +1,10 @@
 import type {
+	WorkflowChildWorkflowInvocation,
 	WorkflowEdge,
+	WorkflowForeachBody,
+	WorkflowForeachDefinition,
+	WorkflowForeachFailureMode,
+	WorkflowForeachOutput,
 	WorkflowModelContext,
 	WorkflowModelUnavailablePolicy,
 	WorkflowNode,
@@ -181,6 +186,10 @@ function parseWorkflowPatchNode(value: unknown, pathLabel: string, missingMessag
 	}
 	const script = parseWorkflowPatchScriptSource(raw.script, `${pathLabel}.script`);
 	if (script !== undefined) node.script = script;
+	const foreach = parseWorkflowPatchForeach(raw.foreach, `${pathLabel}.foreach`);
+	if (foreach !== undefined) node.foreach = foreach;
+	const workflow = parseWorkflowPatchWorkflow(raw.workflow, `${pathLabel}.workflow`);
+	if (workflow !== undefined) node.workflow = workflow;
 	if (raw.gates !== undefined) node.gates = parseWorkflowPatchStringArray(raw.gates, `${pathLabel}.gates`);
 	if (raw.reads !== undefined) node.reads = parseWorkflowPatchStringArray(raw.reads, `${pathLabel}.reads`);
 	if (raw.writes !== undefined) node.writes = parseWorkflowPatchStringArray(raw.writes, `${pathLabel}.writes`);
@@ -216,8 +225,17 @@ function parseWorkflowPatchEdgeCondition(value: unknown, pathLabel: string): Wor
 }
 
 function parseWorkflowPatchNodeType(value: unknown, pathLabel: string): WorkflowNodeType {
-	if (value === "agent" || value === "script" || value === "human" || value === "review") return value;
-	throw new Error(`${pathLabel} must be agent, script, human, or review`);
+	if (
+		value === "agent" ||
+		value === "script" ||
+		value === "human" ||
+		value === "review" ||
+		value === "foreach" ||
+		value === "workflow"
+	) {
+		return value;
+	}
+	throw new Error(`${pathLabel} must be agent, script, human, review, foreach, or workflow`);
 }
 
 function parseWorkflowPatchPrompt(
@@ -402,6 +420,73 @@ function parseWorkflowPatchScriptTimeoutMs(value: unknown, pathLabel: string): n
 		return value;
 	}
 	throw new Error(`${pathLabel} must be a positive integer no greater than ${WORKFLOW_SCRIPT_TIMEOUT_MAX_MS}`);
+}
+
+function parseWorkflowPatchForeach(value: unknown, pathLabel: string): WorkflowForeachDefinition | undefined {
+	if (value === undefined) return undefined;
+	const raw = expectWorkflowPatchRecord(value, pathLabel);
+	const itemName = parseOptionalWorkflowPatchString(raw.itemName, `${pathLabel}.itemName`);
+	const key = parseOptionalWorkflowPatchJsonPointer(raw.key, `${pathLabel}.key`);
+	const concurrency = parseOptionalWorkflowPatchPositiveInteger(raw.concurrency, `${pathLabel}.concurrency`);
+	const failureMode = parseWorkflowPatchForeachFailureMode(raw.failureMode, `${pathLabel}.failureMode`);
+	const foreach: WorkflowForeachDefinition = {
+		items: expectWorkflowPatchJsonPointer(raw.items, `${pathLabel}.items`),
+		failureMode,
+		output: parseWorkflowPatchForeachOutput(raw.output, `${pathLabel}.output`),
+		body: parseWorkflowPatchForeachBody(raw.body, `${pathLabel}.body`),
+	};
+	if (itemName !== undefined) foreach.itemName = itemName;
+	if (key !== undefined) foreach.key = key;
+	if (concurrency !== undefined) foreach.concurrency = concurrency;
+	return foreach;
+}
+
+function parseWorkflowPatchForeachFailureMode(value: unknown, pathLabel: string): WorkflowForeachFailureMode {
+	if (value === undefined) return "failFast";
+	if (value === "failFast" || value === "allSettled" || value === "continueOnError") return value;
+	throw new Error(`${pathLabel} must be failFast, allSettled, or continueOnError`);
+}
+
+function parseWorkflowPatchForeachOutput(value: unknown, pathLabel: string): WorkflowForeachOutput {
+	const raw = expectWorkflowPatchRecord(value, pathLabel);
+	return { path: expectWorkflowPatchJsonPointer(raw.path, `${pathLabel}.path`) };
+}
+
+function parseWorkflowPatchForeachBody(value: unknown, pathLabel: string): WorkflowForeachBody {
+	const raw = expectWorkflowPatchRecord(value, pathLabel);
+	const hasNode = raw.node !== undefined;
+	const hasWorkflow = raw.workflow !== undefined;
+	if (hasNode === hasWorkflow) throw new Error(`${pathLabel} must define exactly one of node or workflow`);
+	if (hasWorkflow) {
+		return { kind: "workflow", workflow: parseWorkflowPatchWorkflowRequired(raw.workflow, `${pathLabel}.workflow`) };
+	}
+	const node = parseWorkflowPatchNode(raw.node, `${pathLabel}.node`, `${pathLabel}.node is required`);
+	if (node.type === "foreach" || node.type === "workflow") {
+		throw new Error(`${pathLabel}.node.type must be agent, script, human, or review`);
+	}
+	return { kind: "node", node };
+}
+
+function parseWorkflowPatchWorkflow(value: unknown, pathLabel: string): WorkflowChildWorkflowInvocation | undefined {
+	if (value === undefined) return undefined;
+	return parseWorkflowPatchWorkflowRequired(value, pathLabel);
+}
+
+function parseWorkflowPatchWorkflowRequired(value: unknown, pathLabel: string): WorkflowChildWorkflowInvocation {
+	if (typeof value === "string") return { path: expectWorkflowPatchString(value, pathLabel) };
+	const raw = expectWorkflowPatchRecord(value, pathLabel);
+	return { path: expectWorkflowPatchString(raw.path, `${pathLabel}.path`) };
+}
+
+function parseOptionalWorkflowPatchJsonPointer(value: unknown, pathLabel: string): string | undefined {
+	if (value === undefined) return undefined;
+	return expectWorkflowPatchJsonPointer(value, pathLabel);
+}
+
+function parseOptionalWorkflowPatchPositiveInteger(value: unknown, pathLabel: string): number | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) return value;
+	throw new Error(`${pathLabel} must be a positive integer`);
 }
 
 function parseRequiredWorkflowPatchModelContext(value: unknown, pathLabel: string): WorkflowModelContext {

--- a/packages/coding-agent/src/workflow/definition.ts
+++ b/packages/coding-agent/src/workflow/definition.ts
@@ -1,10 +1,16 @@
 import { YAML } from "bun";
 import { diagnoseWorkflowConditionReferences, parseWorkflowCondition, WorkflowConditionError } from "./condition";
-import { parseWorkflowStateSchema, type WorkflowStateSchema, WorkflowStateSchemaError } from "./state-schema";
+import {
+	parseWorkflowStateSchema,
+	type WorkflowStateSchema,
+	WorkflowStateSchemaError,
+	workflowStateSchemaDeclaresConditionPath,
+} from "./state-schema";
 
-export type WorkflowNodeType = "agent" | "script" | "human" | "review";
+export type WorkflowNodeType = "agent" | "script" | "human" | "review" | "foreach" | "workflow";
 export type WorkflowModelUnavailablePolicy = "fallback-to-parent" | "fail";
 export type WorkflowScriptLanguage = "js" | "py" | "sh";
+export type WorkflowForeachFailureMode = "failFast" | "allSettled" | "continueOnError";
 export const WORKFLOW_SCRIPT_TIMEOUT_MAX_MS = 60 * 60 * 1000;
 
 export interface WorkflowModelContext {
@@ -120,6 +126,36 @@ export interface WorkflowScriptSource {
 	timeoutMs?: number;
 }
 
+export interface WorkflowChildWorkflowInvocation {
+	path: string;
+}
+
+export interface WorkflowForeachOutput {
+	path: string;
+}
+
+export type WorkflowForeachBody = WorkflowForeachNodeBody | WorkflowForeachWorkflowBody;
+
+export interface WorkflowForeachNodeBody {
+	kind: "node";
+	node: WorkflowNode;
+}
+
+export interface WorkflowForeachWorkflowBody {
+	kind: "workflow";
+	workflow: WorkflowChildWorkflowInvocation;
+}
+
+export interface WorkflowForeachDefinition {
+	items: string;
+	itemName?: string;
+	key?: string;
+	concurrency?: number;
+	failureMode: WorkflowForeachFailureMode;
+	output: WorkflowForeachOutput;
+	body: WorkflowForeachBody;
+}
+
 export interface WorkflowNode {
 	id: string;
 	type: WorkflowNodeType;
@@ -133,6 +169,8 @@ export interface WorkflowNode {
 	reads?: string[];
 	writes?: string[];
 	waitFor?: string[];
+	foreach?: WorkflowForeachDefinition;
+	workflow?: WorkflowChildWorkflowInvocation;
 }
 
 export interface WorkflowDefinition {
@@ -181,6 +219,7 @@ export function parseWorkflowDefinition(
 	const subflows = parseSubflowDeclarations(root.subflows, "subflows", options.sourcePath);
 	validateEdgeReferences(nodes, edges, options.sourcePath);
 	validateConditionReferences(nodes, edges, stateSchema, options.sourcePath);
+	validateForeachStateReferences(nodes, stateSchema, options.sourcePath);
 	validateWaitForReferences(nodes, options.sourcePath);
 	validatePromptSourceReferences(nodes, options.sourcePath);
 	validateMigrationTargets(nodes, migrations, options.sourcePath);
@@ -222,19 +261,7 @@ function parseNodes(value: unknown, sourcePath?: string): WorkflowNode[] {
 			throw new WorkflowDefinitionError(`duplicate node id "${id}"`, sourcePath);
 		}
 		seen.add(id);
-		const node = expectRecord(rawNode, path, sourcePath);
-		const type = parseNodeType(node.type, `${path}.type`, sourcePath);
-		const agent = parseOptionalString(node.agent, `${path}.agent`, sourcePath);
-		const model = parseModelContext(node.model, `${path}.model`, sourcePath);
-		const prompt = parsePromptSource(node.prompt, `${path}.prompt`, sourcePath);
-		const script = parseScriptSource(node.script, `${path}.script`, sourcePath);
-		const gates = parseOptionalStringList(node.gates, `${path}.gates`, sourcePath);
-		const fallbackVerdict = parseOptionalString(node.fallbackVerdict, `${path}.fallbackVerdict`, sourcePath);
-		validateFallbackVerdict(id, type, gates, fallbackVerdict, path, sourcePath);
-		const reads = parseOptionalStringList(node.reads, `${path}.reads`, sourcePath);
-		const writes = parseOptionalStringList(node.writes, `${path}.writes`, sourcePath);
-		const waitFor = parseOptionalStringList(node.waitFor, `${path}.waitFor`, sourcePath);
-		return compactNode({ id, type, agent, model, ...prompt, script, gates, fallbackVerdict, reads, writes, waitFor });
+		return parseWorkflowNode(rawNode, id, path, sourcePath, { bodyNode: false });
 	});
 }
 
@@ -252,6 +279,48 @@ function parseNodeEntries(value: unknown, sourcePath?: string): Array<{ id: stri
 	}
 	const rawNodes = expectRecord(value, "nodes", sourcePath);
 	return Object.entries(rawNodes).map(([id, rawNode]) => ({ id, rawNode, path: `nodes.${id}` }));
+}
+
+function parseWorkflowNode(
+	rawNode: unknown,
+	id: string,
+	path: string,
+	sourcePath: string | undefined,
+	options: { bodyNode: boolean },
+): WorkflowNode {
+	const node = expectRecord(rawNode, path, sourcePath);
+	const type = parseNodeType(node.type, `${path}.type`, sourcePath);
+	if (options.bodyNode && (type === "foreach" || type === "workflow")) {
+		throw new WorkflowDefinitionError(`${path}.type must be agent, script, human, or review`, sourcePath);
+	}
+	const agent = parseOptionalString(node.agent, `${path}.agent`, sourcePath);
+	const model = parseModelContext(node.model, `${path}.model`, sourcePath);
+	const prompt = parsePromptSource(node.prompt, `${path}.prompt`, sourcePath);
+	const script = parseScriptSource(node.script, `${path}.script`, sourcePath);
+	const gates = parseOptionalStringList(node.gates, `${path}.gates`, sourcePath);
+	const fallbackVerdict = parseOptionalString(node.fallbackVerdict, `${path}.fallbackVerdict`, sourcePath);
+	validateFallbackVerdict(id, type, gates, fallbackVerdict, path, sourcePath);
+	const reads = parseOptionalStringList(node.reads, `${path}.reads`, sourcePath);
+	const parsedWrites = parseOptionalStringList(node.writes, `${path}.writes`, sourcePath);
+	const waitFor = parseOptionalStringList(node.waitFor, `${path}.waitFor`, sourcePath);
+	const foreach = parseForeachForNode(type, node.foreach, `${path}.foreach`, sourcePath);
+	const workflow = parseWorkflowInvocationForNode(type, node.workflow, `${path}.workflow`, sourcePath);
+	const writes = mergeNodeWrites(parsedWrites, foreach?.output.path);
+	return compactNode({
+		id,
+		type,
+		agent,
+		model,
+		...prompt,
+		script,
+		gates,
+		fallbackVerdict,
+		reads,
+		writes,
+		waitFor,
+		foreach,
+		workflow,
+	});
 }
 
 function parseEdges(value: unknown, sourcePath?: string): WorkflowEdge[] {
@@ -414,6 +483,23 @@ function validateConditionReferences(
 		if (edge.condition === undefined) continue;
 		for (const diagnostic of diagnoseWorkflowConditionReferences(edge.condition.source, nodes, stateSchema)) {
 			throw new WorkflowDefinitionError(`edges.${index}.when ${diagnostic}`, sourcePath);
+		}
+	}
+}
+
+function validateForeachStateReferences(
+	nodes: WorkflowNode[],
+	stateSchema: WorkflowStateSchema | undefined,
+	sourcePath?: string,
+): void {
+	for (const node of nodes) {
+		const foreach = node.foreach;
+		if (foreach === undefined) continue;
+		if (!workflowStateSchemaDeclaresConditionPath(foreach.items, stateSchema)) {
+			throw new WorkflowDefinitionError(
+				`node "${node.id}" foreach items references undeclared state path "${foreach.items}"`,
+				sourcePath,
+			);
 		}
 	}
 }
@@ -660,6 +746,101 @@ function parseScriptSource(value: unknown, path: string, sourcePath?: string): W
 	return script;
 }
 
+function parseForeachForNode(
+	type: WorkflowNodeType,
+	value: unknown,
+	path: string,
+	sourcePath?: string,
+): WorkflowForeachDefinition | undefined {
+	if (type !== "foreach") {
+		if (value !== undefined) {
+			throw new WorkflowDefinitionError(`${path} is only valid for foreach nodes`, sourcePath);
+		}
+		return undefined;
+	}
+	if (value === undefined) {
+		throw new WorkflowDefinitionError(`${path} must be an object`, sourcePath);
+	}
+	const raw = expectRecord(value, path, sourcePath);
+	const items = expectJsonPointer(raw.items, `${path}.items`, sourcePath);
+	const itemName = parseOptionalString(raw.itemName, `${path}.itemName`, sourcePath);
+	const key = parseOptionalJsonPointer(raw.key, `${path}.key`, sourcePath);
+	const concurrency = parseOptionalPositiveInteger(raw.concurrency, `${path}.concurrency`, sourcePath);
+	const failureMode = parseForeachFailureMode(raw.failureMode, `${path}.failureMode`, sourcePath);
+	const output = parseForeachOutput(raw.output, `${path}.output`, sourcePath);
+	const body = parseForeachBody(raw.body, `${path}.body`, sourcePath);
+	const foreach: WorkflowForeachDefinition = {
+		items,
+		failureMode,
+		output,
+		body,
+	};
+	if (itemName !== undefined) foreach.itemName = itemName;
+	if (key !== undefined) foreach.key = key;
+	if (concurrency !== undefined) foreach.concurrency = concurrency;
+	return foreach;
+}
+
+function parseWorkflowInvocationForNode(
+	type: WorkflowNodeType,
+	value: unknown,
+	path: string,
+	sourcePath?: string,
+): WorkflowChildWorkflowInvocation | undefined {
+	if (type !== "workflow") {
+		if (value !== undefined) {
+			throw new WorkflowDefinitionError(`${path} is only valid for workflow nodes`, sourcePath);
+		}
+		return undefined;
+	}
+	if (value === undefined) {
+		throw new WorkflowDefinitionError(`${path} must be a child workflow invocation`, sourcePath);
+	}
+	return parseWorkflowInvocation(value, path, sourcePath);
+}
+
+function parseForeachFailureMode(value: unknown, path: string, sourcePath?: string): WorkflowForeachFailureMode {
+	if (value === undefined) return "failFast";
+	if (value === "failFast" || value === "allSettled" || value === "continueOnError") return value;
+	throw new WorkflowDefinitionError(`${path} must be failFast, allSettled, or continueOnError`, sourcePath);
+}
+
+function parseForeachOutput(value: unknown, path: string, sourcePath?: string): WorkflowForeachOutput {
+	const raw = expectRecord(value, path, sourcePath);
+	return { path: expectJsonPointer(raw.path, `${path}.path`, sourcePath) };
+}
+
+function parseForeachBody(value: unknown, path: string, sourcePath?: string): WorkflowForeachBody {
+	const raw = expectRecord(value, path, sourcePath);
+	const hasNode = raw.node !== undefined;
+	const hasWorkflow = raw.workflow !== undefined;
+	if (!hasNode && !hasWorkflow && raw.id !== undefined && raw.type !== undefined) {
+		const id = expectString(raw.id, `${path}.id`, sourcePath);
+		return {
+			kind: "node",
+			node: parseWorkflowNode(raw, id, path, sourcePath, { bodyNode: true }),
+		};
+	}
+	if (hasNode === hasWorkflow) {
+		throw new WorkflowDefinitionError(`${path} must define exactly one of node or workflow`, sourcePath);
+	}
+	if (hasWorkflow) {
+		return { kind: "workflow", workflow: parseWorkflowInvocation(raw.workflow, `${path}.workflow`, sourcePath) };
+	}
+	const bodyNodeRaw = expectRecord(raw.node, `${path}.node`, sourcePath);
+	const id = expectString(bodyNodeRaw.id, `${path}.node.id`, sourcePath);
+	return {
+		kind: "node",
+		node: parseWorkflowNode(bodyNodeRaw, id, `${path}.node`, sourcePath, { bodyNode: true }),
+	};
+}
+
+function parseWorkflowInvocation(value: unknown, path: string, sourcePath?: string): WorkflowChildWorkflowInvocation {
+	if (typeof value === "string") return { path: expectString(value, path, sourcePath) };
+	const raw = expectRecord(value, path, sourcePath);
+	return { path: expectString(raw.path, `${path}.path`, sourcePath) };
+}
+
 function parseScriptLanguage(value: unknown, path: string, sourcePath?: string): WorkflowScriptLanguage | undefined {
 	if (value === undefined) return undefined;
 	if (value === "js" || value === "py" || value === "sh") return value;
@@ -693,8 +874,17 @@ function parseUnavailable(
 }
 
 function parseNodeType(value: unknown, path: string, sourcePath?: string): WorkflowNodeType {
-	if (value === "agent" || value === "script" || value === "human" || value === "review") return value;
-	throw new WorkflowDefinitionError(`${path} must be agent, script, human, or review`, sourcePath);
+	if (
+		value === "agent" ||
+		value === "script" ||
+		value === "human" ||
+		value === "review" ||
+		value === "foreach" ||
+		value === "workflow"
+	) {
+		return value;
+	}
+	throw new WorkflowDefinitionError(`${path} must be agent, script, human, review, foreach, or workflow`, sourcePath);
 }
 
 function parsePromptActivationSelector(
@@ -718,6 +908,8 @@ function compactNode(node: WorkflowNode): WorkflowNode {
 	if (node.reads !== undefined) result.reads = node.reads;
 	if (node.writes !== undefined) result.writes = node.writes;
 	if (node.waitFor !== undefined) result.waitFor = node.waitFor;
+	if (node.foreach !== undefined) result.foreach = node.foreach;
+	if (node.workflow !== undefined) result.workflow = node.workflow;
 	return result;
 }
 
@@ -750,6 +942,17 @@ function parseOptionalString(value: unknown, path: string, sourcePath?: string):
 	return expectString(value, path, sourcePath);
 }
 
+function parseOptionalJsonPointer(value: unknown, path: string, sourcePath?: string): string | undefined {
+	if (value === undefined) return undefined;
+	return expectJsonPointer(value, path, sourcePath);
+}
+
+function parseOptionalPositiveInteger(value: unknown, path: string, sourcePath?: string): number | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) return value;
+	throw new WorkflowDefinitionError(`${path} must be a positive integer`, sourcePath);
+}
+
 function expectJsonPointer(value: unknown, path: string, sourcePath?: string): string {
 	const pointer = expectString(value, path, sourcePath);
 	if (pointer.startsWith("/")) return pointer;
@@ -775,4 +978,10 @@ function expectRecord(value: unknown, path: string, sourcePath?: string): Record
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeNodeWrites(writes: string[] | undefined, foreachOutputPath: string | undefined): string[] | undefined {
+	if (foreachOutputPath === undefined) return writes;
+	if (writes === undefined) return [foreachOutputPath];
+	return writes.includes(foreachOutputPath) ? writes : [...writes, foreachOutputPath];
 }

--- a/packages/coding-agent/src/workflow/dsl.ts
+++ b/packages/coding-agent/src/workflow/dsl.ts
@@ -152,13 +152,16 @@ class WorkflowDslCompiler {
 		if (step.parallel !== undefined) {
 			return this.compileParallel(step, path);
 		}
+		if (step.foreach !== undefined) {
+			return this.compileForeach(step.foreach, `${path}.foreach`);
+		}
 		if (step.template !== undefined) {
 			return this.compileTemplate(step.template, `${path}.template`);
 		}
 		if (step.node !== undefined) {
 			return this.compileNode(step.node, `${path}.node`);
 		}
-		throw new WorkflowDslError(`${path} must define one of node, sequence, parallel, template, or use`);
+		throw new WorkflowDslError(`${path} must define one of node, sequence, parallel, foreach, template, or use`);
 	}
 
 	compileSequence(steps: unknown[], path: string): CompileResult {
@@ -199,6 +202,14 @@ class WorkflowDslCompiler {
 		const node = this.normalizeNode(rawNode, path);
 		this.addNode(node, path);
 		return { entries: [node.id], exits: [nodeExit(node.id)] };
+	}
+
+	compileForeach(rawForeach: unknown, path: string): CompileResult {
+		const foreach = { ...expectRecord(rawForeach, path) };
+		const id = expectString(foreach.id, `${path}.id`);
+		delete foreach.id;
+		this.addNode({ id, type: "foreach", foreach }, path);
+		return { entries: [id], exits: [nodeExit(id)] };
 	}
 
 	compileExternalModule(moduleName: string, externalModule: WorkflowDslExternalModule, path: string): CompileResult {
@@ -277,6 +288,7 @@ class WorkflowDslCompiler {
 			branch.node !== undefined ||
 			branch.sequence !== undefined ||
 			branch.parallel !== undefined ||
+			branch.foreach !== undefined ||
 			branch.template !== undefined ||
 			branch.use !== undefined
 		) {

--- a/packages/coding-agent/src/workflow/freeze.ts
+++ b/packages/coding-agent/src/workflow/freeze.ts
@@ -16,6 +16,7 @@ export interface FlowFreeze {
 	resourceDir: string;
 	mainContentHash: string;
 	resourceHashes: FlowFreezeResourceHash[];
+	childWorkflowHashes?: FlowFreezeResourceHash[];
 	resourceSnapshots: FlowFreezeResourceSnapshot[];
 	canonicalGraphHash: string;
 	sourceMapping: WorkflowArtifact["sourceMapping"];
@@ -77,9 +78,11 @@ export async function freezeWorkflowArtifact(artifact: WorkflowArtifact): Promis
 	validateNodeRuntimeContracts(artifact.definition);
 	const resourceReferences = collectResourceReferences(artifact);
 	await validateReferencedResources(artifact.resourceDir, resourceReferences);
+	await validateChildWorkflowReferences(artifact);
 	await validateDeclaredChangeRequestFiles(artifact);
 	const resourceHashes = await hashResourceDirectory(artifact.resourceDir);
 	const resourceSnapshots = await snapshotReferencedResources(artifact.resourceDir, resourceReferences);
+	const childWorkflowHashes = await hashChildWorkflowReferences(artifact);
 	const canonicalGraphHash = contentHash(stableStringify(canonicalGraph(artifact.definition)));
 	const mainContentHash = contentHash(artifact.source);
 	const schemaVersion = artifact.metadata.schema;
@@ -89,10 +92,11 @@ export async function freezeWorkflowArtifact(artifact: WorkflowArtifact): Promis
 			mainContentHash,
 			resourceHashes,
 			resourceSnapshots,
+			childWorkflowHashes,
 			canonicalGraphHash,
 		}),
 	).slice("sha256:".length)}`;
-	return {
+	const freeze: FlowFreeze = {
 		id,
 		schemaVersion,
 		flowPath: artifact.flowPath,
@@ -109,6 +113,8 @@ export async function freezeWorkflowArtifact(artifact: WorkflowArtifact): Promis
 		changeRequests: structuredClone(artifact.changeRequests),
 		definition: structuredClone(artifact.definition),
 	};
+	if (childWorkflowHashes.length > 0) freeze.childWorkflowHashes = childWorkflowHashes;
+	return freeze;
 }
 
 function buildStaticCheckReport(definition: WorkflowDefinition): WorkflowStaticCheckReport {
@@ -120,6 +126,8 @@ function buildStaticCheckReport(definition: WorkflowDefinition): WorkflowStaticC
 	];
 	const stateSchemaCheck = workflowStateSchemaCheck(definition);
 	if (stateSchemaCheck !== undefined) checks.push(stateSchemaCheck);
+	const dynamicTopologyCheck = workflowDynamicTopologyCheck(definition);
+	if (dynamicTopologyCheck !== undefined) checks.push(dynamicTopologyCheck);
 	checks.push({ name: "canonical-graph", status: "passed" });
 	return { status: "passed", checks };
 }
@@ -132,6 +140,25 @@ function workflowStateSchemaCheck(definition: WorkflowDefinition): WorkflowStati
 		details: Object.entries(definition.stateSchema.shape)
 			.sort(([left], [right]) => left.localeCompare(right))
 			.map(([field, type]) => `${field}: ${type}`),
+	};
+}
+
+function workflowDynamicTopologyCheck(definition: WorkflowDefinition): WorkflowStaticCheck | undefined {
+	const details: string[] = [];
+	for (const node of definition.nodes) {
+		if (node.foreach !== undefined) {
+			details.push(`foreach ${node.id} reads ${node.foreach.items} -> ${node.foreach.output.path}`);
+			if (node.foreach.body.kind === "workflow") {
+				details.push(`child workflow ${node.id} -> ${node.foreach.body.workflow.path}`);
+			}
+		}
+		if (node.workflow !== undefined) details.push(`child workflow ${node.id} -> ${node.workflow.path}`);
+	}
+	if (details.length === 0) return undefined;
+	return {
+		name: "dynamic-topology",
+		status: "passed",
+		details,
 	};
 }
 
@@ -183,25 +210,28 @@ function validateFreezeMetadata(artifact: WorkflowArtifact): {
 
 function validateNodeRuntimeContracts(definition: WorkflowDefinition): void {
 	for (const node of definition.nodes) {
-		validateNodeStateScopes(node);
-		validatePromptReadScope(node);
-		if (node.type === "script" && !node.script?.code && !node.script?.file) {
-			throw new WorkflowFreezeError(
-				`workflow script node "${node.id}" must define inline code or a script file before production freeze`,
-			);
-		}
-		if (node.type === "agent" && !node.agent) {
-			throw new WorkflowFreezeError(
-				`workflow agent node "${node.id}" must define an agent before production freeze`,
-			);
-		}
-		if ((node.type === "human" || node.type === "review") && !node.promptSource && !node.prompt?.trim()) {
-			throw new WorkflowFreezeError(
-				`workflow ${node.type} node "${node.id}" must define a prompt before production freeze`,
-			);
-		}
+		validateNodeRuntimeContract(node);
+		if (node.foreach?.body.kind === "node") validateNodeRuntimeContract(node.foreach.body.node);
 	}
 	validateLoopProgressContracts(definition);
+}
+
+function validateNodeRuntimeContract(node: WorkflowNode): void {
+	validateNodeStateScopes(node);
+	validatePromptReadScope(node);
+	if (node.type === "script" && !node.script?.code && !node.script?.file) {
+		throw new WorkflowFreezeError(
+			`workflow script node "${node.id}" must define inline code or a script file before production freeze`,
+		);
+	}
+	if (node.type === "agent" && !node.agent) {
+		throw new WorkflowFreezeError(`workflow agent node "${node.id}" must define an agent before production freeze`);
+	}
+	if ((node.type === "human" || node.type === "review") && !node.promptSource && !node.prompt?.trim()) {
+		throw new WorkflowFreezeError(
+			`workflow ${node.type} node "${node.id}" must define a prompt before production freeze`,
+		);
+	}
 }
 
 function validateNodeStateScopes(node: WorkflowNode): void {
@@ -358,19 +388,77 @@ function collectResourceReferences(artifact: WorkflowArtifact): string[] {
 	const references: string[] = [];
 	const definition = artifact.definition;
 	for (const node of definition.nodes) {
-		if (node.promptSource?.kind === "file") {
-			references.push(node.promptSource.path);
-		}
-		if (node.promptSource?.kind === "template") {
-			references.push(node.promptSource.file);
-		}
-		if (node.script?.file) {
-			references.push(node.script.file);
-		}
+		references.push(...collectNodeResourceReferences(node));
+		if (node.foreach?.body.kind === "node") references.push(...collectNodeResourceReferences(node.foreach.body.node));
 	}
 	for (const resource of definition.resources ?? []) references.push(resource.path);
 	for (const request of artifact.changeRequests) references.push(request.path);
 	return references;
+}
+
+function collectNodeResourceReferences(node: WorkflowNode): string[] {
+	const references: string[] = [];
+	if (node.promptSource?.kind === "file") {
+		references.push(node.promptSource.path);
+	}
+	if (node.promptSource?.kind === "template") {
+		references.push(node.promptSource.file);
+	}
+	if (node.script?.file) {
+		references.push(node.script.file);
+	}
+	return references;
+}
+
+async function validateChildWorkflowReferences(artifact: WorkflowArtifact): Promise<void> {
+	for (const node of artifact.definition.nodes) {
+		if (node.workflow !== undefined) {
+			await validateChildWorkflowReference(artifact.flowPath, node.id, node.workflow.path);
+		}
+		if (node.foreach?.body.kind === "workflow") {
+			await validateChildWorkflowReference(artifact.flowPath, node.id, node.foreach.body.workflow.path);
+		}
+	}
+}
+
+async function hashChildWorkflowReferences(artifact: WorkflowArtifact): Promise<FlowFreezeResourceHash[]> {
+	const root = path.dirname(artifact.flowPath);
+	const hashes: FlowFreezeResourceHash[] = [];
+	const seen = new Set<string>();
+	for (const childPath of collectChildWorkflowReferences(artifact.definition)) {
+		const resolved = path.resolve(root, childPath);
+		const relative = path.relative(root, resolved).split(path.sep).join("/");
+		if (seen.has(relative)) continue;
+		seen.add(relative);
+		hashes.push({
+			path: relative,
+			hash: await fileHash(resolved),
+		});
+	}
+	return hashes.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function collectChildWorkflowReferences(definition: WorkflowDefinition): string[] {
+	const references: string[] = [];
+	for (const node of definition.nodes) {
+		if (node.workflow !== undefined) references.push(node.workflow.path);
+		if (node.foreach?.body.kind === "workflow") references.push(node.foreach.body.workflow.path);
+	}
+	return references;
+}
+
+async function validateChildWorkflowReference(flowPath: string, nodeId: string, childPath: string): Promise<void> {
+	const resolved = path.resolve(path.dirname(flowPath), childPath);
+	if (path.extname(resolved) !== ".omhflow") {
+		throw new WorkflowFreezeError(`workflow child node "${nodeId}" must reference a .omhflow file: "${childPath}"`);
+	}
+	try {
+		const stat = await fs.stat(resolved);
+		if (stat.isFile()) return;
+	} catch {
+		throw new WorkflowFreezeError(`workflow child node "${nodeId}" references unreadable child flow "${childPath}"`);
+	}
+	throw new WorkflowFreezeError(`workflow child node "${nodeId}" references unreadable child flow "${childPath}"`);
 }
 
 async function resolveResourcePath(resourceDir: string, resourcePath: string): Promise<string> {

--- a/packages/coding-agent/src/workflow/graph-view.ts
+++ b/packages/coding-agent/src/workflow/graph-view.ts
@@ -37,6 +37,7 @@ export interface WorkflowGraphView {
 	changes: WorkflowGraphChangeCounts;
 	topology: WorkflowGraphTopologyView;
 	subflows?: WorkflowGraphSubflowView[];
+	childWorkflows?: WorkflowGraphChildWorkflowView[];
 	activeAgents?: WorkflowGraphActiveAgentView[];
 	focus?: WorkflowGraphFocusView;
 	nodes: WorkflowGraphNodeView[];
@@ -66,6 +67,8 @@ export interface WorkflowGraphTopologyView {
 	joins: number;
 	loops: number;
 	subflows: number;
+	dynamicFanOuts?: number;
+	childWorkflows?: number;
 }
 
 export interface WorkflowGraphSubflowView {
@@ -77,6 +80,12 @@ export interface WorkflowGraphSubflowView {
 	entryNodeIds: string[];
 	exitNodeIds: string[];
 	resourcePrefix?: string;
+}
+
+export interface WorkflowGraphChildWorkflowView {
+	nodeId: string;
+	path: string;
+	withinForeach: boolean;
 }
 
 export interface WorkflowGraphActiveAgentView {
@@ -240,7 +249,14 @@ export function buildWorkflowGraphView(
 			if (edge.label !== undefined) view.label = edge.label;
 			return view;
 		}) ?? [];
-	const topology = buildWorkflowGraphTopology(nodes, edges, currentFreeze?.definition.subflows?.length ?? 0);
+	const childWorkflows = formatWorkflowChildWorkflows(currentFreeze?.definition.nodes ?? []);
+	const topology = buildWorkflowGraphTopology(
+		nodes,
+		edges,
+		currentFreeze?.definition.subflows?.length ?? 0,
+		currentFreeze?.definition.nodes ?? [],
+		childWorkflows.length,
+	);
 	const selectedRoutes = buildWorkflowGraphSelectedRoutes(currentAttempt, edges);
 	const activeAgents = formatActiveWorkflowAgents(currentAttempt, currentFreeze?.definition.nodes ?? [], options);
 	const focus = buildWorkflowGraphFocus(nodes, activeAgents, currentAttempt);
@@ -274,6 +290,7 @@ export function buildWorkflowGraphView(
 			...(subflow.resourcePrefix !== undefined ? { resourcePrefix: subflow.resourcePrefix } : {}),
 		}));
 	}
+	if (childWorkflows.length > 0) view.childWorkflows = childWorkflows;
 	if (activeAgents.length > 0) view.activeAgents = activeAgents;
 	if (family.objective !== undefined) view.objective = family.objective;
 	if (latestFreeze?.id !== undefined) view.latestFreezeId = latestFreeze.id;
@@ -313,6 +330,10 @@ export function renderWorkflowGraphText(view: WorkflowGraphView, options: Workfl
 	if (view.subflows !== undefined && view.subflows.length > 0) {
 		lines.push("Flow calls:");
 		for (const subflow of view.subflows) lines.push(`- ${formatWorkflowSubflow(subflow)}`);
+	}
+	if (view.childWorkflows !== undefined && view.childWorkflows.length > 0) {
+		lines.push("Child workflows:");
+		for (const childWorkflow of view.childWorkflows) lines.push(`- ${formatWorkflowChildWorkflow(childWorkflow)}`);
 	}
 	const onFlight = formatWorkflowOnFlightLines(view);
 	if (onFlight.length > 0) {
@@ -427,6 +448,8 @@ function buildWorkflowGraphTopology(
 	nodes: readonly WorkflowGraphNodeView[],
 	edges: readonly WorkflowGraphEdgeView[],
 	subflows: number,
+	definitionNodes: readonly WorkflowNode[],
+	childWorkflows: number,
 ): WorkflowGraphTopologyView {
 	const order = new Map(nodes.map((node, index) => [node.id, index]));
 	const outgoing = new Map<string, WorkflowGraphEdgeView[]>();
@@ -453,7 +476,11 @@ function buildWorkflowGraphTopology(
 	for (const edge of edges) {
 		if (isWorkflowBackEdge(edge, order)) loops += 1;
 	}
-	return { parallelFanOuts, branchPoints, joins, loops, subflows };
+	const topology: WorkflowGraphTopologyView = { parallelFanOuts, branchPoints, joins, loops, subflows };
+	const dynamicFanOuts = definitionNodes.filter(node => node.type === "foreach").length;
+	if (dynamicFanOuts > 0) topology.dynamicFanOuts = dynamicFanOuts;
+	if (childWorkflows > 0) topology.childWorkflows = childWorkflows;
+	return topology;
 }
 
 function isWorkflowBackEdge(edge: WorkflowGraphEdgeView, order: Map<string, number>): boolean {
@@ -1770,7 +1797,22 @@ function isFocusedWorkflowGraphNode(status: WorkflowGraphNodeStatus): boolean {
 }
 
 function formatWorkflowNodeKind(node: WorkflowNode): string {
+	if (node.type === "foreach") return "foreach";
+	if (node.type === "workflow") return "workflow";
 	return formatWorkflowNodeRole(node);
+}
+
+function formatWorkflowChildWorkflows(nodes: readonly WorkflowNode[]): WorkflowGraphChildWorkflowView[] {
+	const childWorkflows: WorkflowGraphChildWorkflowView[] = [];
+	for (const node of nodes) {
+		if (node.workflow !== undefined) {
+			childWorkflows.push({ nodeId: node.id, path: node.workflow.path, withinForeach: false });
+		}
+		if (node.foreach?.body.kind === "workflow") {
+			childWorkflows.push({ nodeId: node.id, path: node.foreach.body.workflow.path, withinForeach: true });
+		}
+	}
+	return childWorkflows;
 }
 
 function formatActiveWorkflowAgents(
@@ -1988,6 +2030,9 @@ function formatWorkflowViewTopology(view: WorkflowGraphView): string {
 
 function formatWorkflowTopologyParts(topology: WorkflowGraphTopologyView): string[] {
 	const parts: string[] = [];
+	if ((topology.dynamicFanOuts ?? 0) > 0) {
+		parts.push(`dynamic fan-outs ${topology.dynamicFanOuts}`);
+	}
 	if (topology.parallelFanOuts > 0) {
 		parts.push(`parallel fan-outs ${topology.parallelFanOuts}`);
 	}
@@ -1995,6 +2040,7 @@ function formatWorkflowTopologyParts(topology: WorkflowGraphTopologyView): strin
 	if (topology.joins > 0) parts.push(`joins ${topology.joins}`);
 	if (topology.loops > 0) parts.push(`loops ${topology.loops}`);
 	if (topology.subflows > 0) parts.push(`subflows ${topology.subflows}`);
+	if ((topology.childWorkflows ?? 0) > 0) parts.push(`child workflows ${topology.childWorkflows}`);
 	return parts;
 }
 
@@ -2160,6 +2206,11 @@ export function formatWorkflowSubflow(subflow: WorkflowGraphSubflowView): string
 	const exits = subflow.exitNodeIds.map(nodeId => formatSubflowNodeReference(subflow, nodeId)).join(", ") || "none";
 	const resources = subflow.resourcePrefix === undefined ? "" : ` · resources ${subflow.resourcePrefix}`;
 	return `${subflow.alias} calls ${subflow.name}@${subflow.version} · ${subflow.nodeCount} ${pluralNode(subflow.nodeCount)} · entry ${entries} · exit ${exits}${resources}`;
+}
+
+export function formatWorkflowChildWorkflow(childWorkflow: WorkflowGraphChildWorkflowView): string {
+	const mode = childWorkflow.withinForeach ? "foreach invokes" : "invokes";
+	return `${childWorkflow.nodeId} ${mode} ${childWorkflow.path}`;
 }
 
 function formatSubflowNodeReference(subflow: WorkflowGraphSubflowView, nodeId: string): string {

--- a/packages/coding-agent/src/workflow/node-runtime.ts
+++ b/packages/coding-agent/src/workflow/node-runtime.ts
@@ -1,6 +1,13 @@
-import type { WorkflowModelContext, WorkflowNode, WorkflowScriptLanguage } from "./definition";
+import type {
+	WorkflowChildWorkflowInvocation,
+	WorkflowForeachBody,
+	WorkflowForeachDefinition,
+	WorkflowModelContext,
+	WorkflowNode,
+	WorkflowScriptLanguage,
+} from "./definition";
 import type { WorkflowActivation } from "./scheduler";
-import type { WorkflowActivationOutput } from "./state";
+import { readWorkflowState, type WorkflowActivationOutput } from "./state";
 
 export interface WorkflowNodeRuntimeInput {
 	node: WorkflowNode;
@@ -44,11 +51,30 @@ export interface WorkflowReviewNodeOutput {
 	artifacts?: string[];
 }
 
+export interface WorkflowWorkflowNodeInput extends WorkflowNodeRuntimeInput {
+	workflowPath: string;
+	state: Record<string, unknown>;
+	item?: unknown;
+	itemKey?: string;
+	itemIndex?: number;
+	parentNodeId?: string;
+	workflowBasePath?: string;
+}
+
+export interface WorkflowWorkflowNodeOutput {
+	summary?: string;
+	data?: Record<string, unknown>;
+	artifacts?: string[];
+	childFamilyId: string;
+	childAttemptId: string;
+}
+
 export interface WorkflowNodeRuntimeHost {
 	runAgentNode?: (input: WorkflowAgentNodeInput) => Promise<WorkflowActivationOutput>;
 	runScriptNode?: (input: WorkflowScriptNodeInput) => Promise<WorkflowActivationOutput>;
 	runHumanNode?: (input: WorkflowHumanNodeInput) => Promise<WorkflowActivationOutput>;
 	runReviewNode?: (input: WorkflowReviewNodeInput) => Promise<WorkflowReviewNodeOutput>;
+	runWorkflowNode?: (input: WorkflowWorkflowNodeInput) => Promise<WorkflowWorkflowNodeOutput>;
 }
 
 export interface WorkflowNodeExecutionContext {
@@ -73,6 +99,7 @@ export interface WorkflowNodeRuntimeOptions {
 	signal?: AbortSignal;
 	context?: WorkflowNodeExecutionContext;
 	resourceDir?: string;
+	workflowBasePath?: string;
 }
 
 export class WorkflowNodeRuntimeError extends Error {
@@ -99,6 +126,12 @@ export async function executeWorkflowNode(
 	}
 	if (node.type === "review") {
 		return executeReviewNode(node, activation, host, options);
+	}
+	if (node.type === "foreach") {
+		return executeForeachNode(node, activation, host, options);
+	}
+	if (node.type === "workflow") {
+		return executeWorkflowInvocationNode(node, activation, host, options);
 	}
 	throw new WorkflowNodeRuntimeError(`unsupported workflow node type: ${node.type}`);
 }
@@ -252,4 +285,388 @@ async function executeReviewNode(
 
 function reviewVerdictStatePath(node: WorkflowNode): string {
 	return node.writes?.[0] ?? "/verdict";
+}
+
+async function executeWorkflowInvocationNode(
+	node: WorkflowNode,
+	activation: WorkflowActivation,
+	host: WorkflowNodeRuntimeHost,
+	options: WorkflowNodeRuntimeOptions,
+): Promise<WorkflowActivationOutput> {
+	if (node.workflow === undefined) {
+		throw new WorkflowNodeRuntimeError(`workflow node "${node.id}" must define a child workflow invocation`);
+	}
+	const output = await runChildWorkflowInvocation(node.workflow, node, activation, host, options, {
+		state: options.context?.state ?? {},
+	});
+	return childWorkflowOutputToActivationOutput(output);
+}
+
+async function executeForeachNode(
+	node: WorkflowNode,
+	activation: WorkflowActivation,
+	host: WorkflowNodeRuntimeHost,
+	options: WorkflowNodeRuntimeOptions,
+): Promise<WorkflowActivationOutput> {
+	const foreach = node.foreach;
+	if (foreach === undefined) {
+		throw new WorkflowNodeRuntimeError(`foreach node "${node.id}" must define foreach metadata`);
+	}
+	const parentState = options.context?.state;
+	if (parentState === undefined) {
+		throw new WorkflowNodeRuntimeError(`foreach node "${node.id}" requires workflow state context`);
+	}
+	const items = readWorkflowState(parentState, foreach.items);
+	if (!Array.isArray(items)) {
+		throw new WorkflowNodeRuntimeError(
+			`foreach node "${node.id}" items path "${foreach.items}" must resolve to an array`,
+		);
+	}
+	const records = createForeachItemRecords(foreach, items);
+	const failFastError = await runForeachItemPool({
+		node,
+		activation,
+		host,
+		options,
+		foreach,
+		items,
+		records,
+		parentState,
+	});
+	if (failFastError !== undefined && foreach.failureMode === "failFast") {
+		throw new WorkflowNodeRuntimeError(failFastError);
+	}
+	const aggregate = {
+		records: records.map(record => compactForeachItemRecord(record)),
+		lifecycle: foreachLifecycle(records),
+	};
+	return {
+		summary: formatForeachSummary(node, aggregate.lifecycle),
+		data: aggregate,
+		statePatch: [{ op: "set", path: foreach.output.path, value: aggregate }],
+	};
+}
+
+type WorkflowForeachItemStatus = "queued" | "running" | "completed" | "failed" | "aborted";
+
+interface WorkflowForeachItemRecord {
+	key: string;
+	index: number;
+	status: WorkflowForeachItemStatus;
+	summary?: string;
+	data?: Record<string, unknown>;
+	artifacts?: string[];
+	error?: string;
+	childFamilyId?: string;
+	childAttemptId?: string;
+}
+
+interface WorkflowForeachLifecycle {
+	queuedKeys: string[];
+	runningKeys: string[];
+	completedKeys: string[];
+	failedKeys: string[];
+	abortedKeys: string[];
+}
+
+interface WorkflowForeachPoolInput {
+	node: WorkflowNode;
+	activation: WorkflowActivation;
+	host: WorkflowNodeRuntimeHost;
+	options: WorkflowNodeRuntimeOptions;
+	foreach: WorkflowForeachDefinition;
+	items: unknown[];
+	records: WorkflowForeachItemRecord[];
+	parentState: Record<string, unknown>;
+}
+
+function createForeachItemRecords(foreach: WorkflowForeachDefinition, items: unknown[]): WorkflowForeachItemRecord[] {
+	const seen = new Set<string>();
+	return items.map((item, index) => {
+		const key = foreachItemKey(foreach, item, index);
+		if (seen.has(key)) {
+			throw new WorkflowNodeRuntimeError(`foreach item key "${key}" is not unique`);
+		}
+		seen.add(key);
+		return { key, index, status: "queued" };
+	});
+}
+
+async function runForeachItemPool(input: WorkflowForeachPoolInput): Promise<string | undefined> {
+	let nextIndex = 0;
+	let stopScheduling = false;
+	let failFastError: string | undefined;
+	const workerCount = Math.min(input.foreach.concurrency ?? 1, input.items.length);
+	const workers = Array.from({ length: workerCount }, () =>
+		runForeachWorker(input, {
+			nextIndex: () => {
+				if (stopScheduling || workflowAbortReason(input.options.signal)) return undefined;
+				const index = nextIndex;
+				nextIndex += 1;
+				return index < input.items.length ? index : undefined;
+			},
+			stop: (error: string | undefined) => {
+				stopScheduling = true;
+				if (error !== undefined && failFastError === undefined) failFastError = error;
+			},
+		}),
+	);
+	await Promise.all(workers);
+	return failFastError;
+}
+
+interface WorkflowForeachWorkerControl {
+	nextIndex: () => number | undefined;
+	stop: (error: string | undefined) => void;
+}
+
+async function runForeachWorker(input: WorkflowForeachPoolInput, control: WorkflowForeachWorkerControl): Promise<void> {
+	while (true) {
+		const index = control.nextIndex();
+		if (index === undefined) return;
+		const record = input.records[index];
+		const item = input.items[index];
+		if (record === undefined || item === undefined) return;
+		record.status = "running";
+		try {
+			const output = await executeForeachBody(input, item, record);
+			record.status = "completed";
+			copyForeachOutputToRecord(record, output);
+			if (workflowAbortReason(input.options.signal)) control.stop(undefined);
+		} catch (error) {
+			const message = formatError(error);
+			if (workflowAbortReason(input.options.signal)) {
+				record.status = "aborted";
+				record.error = message;
+				control.stop(undefined);
+				continue;
+			}
+			record.status = "failed";
+			record.error = message;
+			if (input.foreach.failureMode === "failFast") {
+				control.stop(`foreach node "${input.node.id}" item "${record.key}" failed: ${message}`);
+			}
+		}
+	}
+}
+
+async function executeForeachBody(
+	input: WorkflowForeachPoolInput,
+	item: unknown,
+	record: WorkflowForeachItemRecord,
+): Promise<WorkflowActivationOutput> {
+	if (input.foreach.body.kind === "workflow") {
+		const childOutput = await runChildWorkflowInvocation(
+			input.foreach.body.workflow,
+			input.node,
+			itemActivation(input.activation, input.node, record),
+			input.host,
+			input.options,
+			{
+				state: foreachItemState(input.parentState, input.foreach, item),
+				item,
+				itemKey: record.key,
+				itemIndex: record.index,
+				parentNodeId: input.node.id,
+			},
+		);
+		return childWorkflowOutputToActivationOutput(childOutput);
+	}
+	return executeForeachNodeBody(input.foreach.body, input, item, record);
+}
+
+function executeForeachNodeBody(
+	body: Extract<WorkflowForeachBody, { kind: "node" }>,
+	input: WorkflowForeachPoolInput,
+	item: unknown,
+	record: WorkflowForeachItemRecord,
+): Promise<WorkflowActivationOutput> {
+	return executeWorkflowNode(body.node, itemActivation(input.activation, body.node, record), input.host, {
+		...input.options,
+		context: {
+			state: foreachItemState(input.parentState, input.foreach, item),
+			completedActivations: input.options.context?.completedActivations ?? [],
+		},
+	});
+}
+
+function itemActivation(
+	parentActivation: WorkflowActivation,
+	node: WorkflowNode,
+	record: WorkflowForeachItemRecord,
+): WorkflowActivation {
+	return {
+		id: `${parentActivation.id}:item:${record.key}`,
+		nodeId: node.id,
+		graphRevisionId: parentActivation.graphRevisionId,
+		status: "running",
+		parentActivationIds: [parentActivation.id],
+	};
+}
+
+function foreachItemState(
+	parentState: Record<string, unknown>,
+	foreach: WorkflowForeachDefinition,
+	item: unknown,
+): Record<string, unknown> {
+	const state = structuredClone(parentState);
+	state[foreach.itemName ?? "item"] = item;
+	return state;
+}
+
+async function runChildWorkflowInvocation(
+	invocation: WorkflowChildWorkflowInvocation,
+	node: WorkflowNode,
+	activation: WorkflowActivation,
+	host: WorkflowNodeRuntimeHost,
+	options: WorkflowNodeRuntimeOptions,
+	extra: {
+		state: Record<string, unknown>;
+		item?: unknown;
+		itemKey?: string;
+		itemIndex?: number;
+		parentNodeId?: string;
+	},
+): Promise<WorkflowWorkflowNodeOutput> {
+	if (!host.runWorkflowNode) {
+		throw new WorkflowNodeRuntimeError("workflow runtime host does not support child workflow nodes");
+	}
+	const input: WorkflowWorkflowNodeInput = {
+		node,
+		activation,
+		workflowPath: invocation.path,
+		state: extra.state,
+	};
+	if (options.signal !== undefined) input.signal = options.signal;
+	if (options.workflowBasePath !== undefined) input.workflowBasePath = options.workflowBasePath;
+	if (extra.item !== undefined) input.item = extra.item;
+	if (extra.itemKey !== undefined) input.itemKey = extra.itemKey;
+	if (extra.itemIndex !== undefined) input.itemIndex = extra.itemIndex;
+	if (extra.parentNodeId !== undefined) input.parentNodeId = extra.parentNodeId;
+	return host.runWorkflowNode(input);
+}
+
+function childWorkflowOutputToActivationOutput(output: WorkflowWorkflowNodeOutput): WorkflowActivationOutput {
+	assertNoTranscriptRecord(output.data);
+	const data: Record<string, unknown> = {
+		...(output.data ?? {}),
+		childFamilyId: output.childFamilyId,
+		childAttemptId: output.childAttemptId,
+	};
+	const result: WorkflowActivationOutput = { data };
+	if (output.summary !== undefined) result.summary = output.summary;
+	if (output.artifacts !== undefined) result.artifacts = output.artifacts;
+	return result;
+}
+
+function copyForeachOutputToRecord(record: WorkflowForeachItemRecord, output: WorkflowActivationOutput): void {
+	assertNoTranscriptRecord(output.data);
+	if (output.summary !== undefined) record.summary = output.summary;
+	if (output.data !== undefined) {
+		const childFamilyId = output.data.childFamilyId;
+		const childAttemptId = output.data.childAttemptId;
+		const data = { ...output.data };
+		delete data.childFamilyId;
+		delete data.childAttemptId;
+		if (Object.keys(data).length > 0) record.data = data;
+		if (typeof childFamilyId === "string") record.childFamilyId = childFamilyId;
+		if (typeof childAttemptId === "string") record.childAttemptId = childAttemptId;
+	}
+	if (output.artifacts !== undefined) record.artifacts = output.artifacts;
+}
+
+function compactForeachItemRecord(record: WorkflowForeachItemRecord): WorkflowForeachItemRecord {
+	const compacted: WorkflowForeachItemRecord = {
+		key: record.key,
+		index: record.index,
+		status: record.status,
+	};
+	if (record.summary !== undefined) compacted.summary = record.summary;
+	if (record.data !== undefined) compacted.data = record.data;
+	if (record.artifacts !== undefined) compacted.artifacts = record.artifacts;
+	if (record.error !== undefined) compacted.error = record.error;
+	if (record.childFamilyId !== undefined) compacted.childFamilyId = record.childFamilyId;
+	if (record.childAttemptId !== undefined) compacted.childAttemptId = record.childAttemptId;
+	return compacted;
+}
+
+function foreachLifecycle(records: WorkflowForeachItemRecord[]): WorkflowForeachLifecycle {
+	return {
+		queuedKeys: records.filter(record => record.status === "queued").map(record => record.key),
+		runningKeys: records.filter(record => record.status === "running").map(record => record.key),
+		completedKeys: records.filter(record => record.status === "completed").map(record => record.key),
+		failedKeys: records.filter(record => record.status === "failed").map(record => record.key),
+		abortedKeys: records.filter(record => record.status === "aborted").map(record => record.key),
+	};
+}
+
+function foreachItemKey(foreach: WorkflowForeachDefinition, item: unknown, index: number): string {
+	if (foreach.key === undefined) return String(index);
+	const value = readJsonPointer(item, foreach.key);
+	if (value === undefined || value === null) {
+		throw new WorkflowNodeRuntimeError(`foreach item ${index} key path "${foreach.key}" is missing`);
+	}
+	if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value);
+	throw new WorkflowNodeRuntimeError(`foreach item ${index} key path "${foreach.key}" must resolve to a scalar`);
+}
+
+function readJsonPointer(value: unknown, pointer: string): unknown {
+	let current = value;
+	for (const segment of parseJsonPointer(pointer)) {
+		if (Array.isArray(current)) {
+			const index = Number(segment);
+			if (!Number.isSafeInteger(index) || index < 0) return undefined;
+			current = current[index];
+			continue;
+		}
+		if (!isRecord(current)) return undefined;
+		current = current[segment];
+	}
+	return current;
+}
+
+function parseJsonPointer(pointer: string): string[] {
+	if (pointer === "") return [];
+	if (!pointer.startsWith("/")) {
+		throw new WorkflowNodeRuntimeError(`workflow state path must be a JSON pointer: ${pointer}`);
+	}
+	return pointer
+		.slice(1)
+		.split("/")
+		.map(segment => segment.replaceAll("~1", "/").replaceAll("~0", "~"));
+}
+
+function formatForeachSummary(node: WorkflowNode, lifecycle: WorkflowForeachLifecycle): string {
+	const failed = lifecycle.failedKeys.length;
+	const aborted = lifecycle.abortedKeys.length;
+	const completed = lifecycle.completedKeys.length;
+	if (aborted > 0) return `foreach ${node.id} stopped after ${completed} completed, ${aborted} aborted`;
+	if (failed > 0) return `foreach ${node.id} completed with ${failed} failed item${failed === 1 ? "" : "s"}`;
+	return `foreach ${node.id} completed ${completed} item${completed === 1 ? "" : "s"}`;
+}
+
+function assertNoTranscriptRecord(data: Record<string, unknown> | undefined): void {
+	if (data === undefined) return;
+	for (const field of ["transcript", "rawTranscript", "rawOutput"]) {
+		if (data[field] !== undefined) {
+			throw new WorkflowNodeRuntimeError("workflow item output must store transcripts as artifact references");
+		}
+	}
+}
+
+function workflowAbortReason(signal: AbortSignal | undefined): string | undefined {
+	if (!signal?.aborted) return undefined;
+	const reason: unknown = signal.reason;
+	if (reason instanceof Error) return reason.message;
+	if (typeof reason === "string" && reason.length > 0) return reason;
+	if (reason !== undefined && reason !== null) return String(reason);
+	return "workflow activation aborted";
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/coding-agent/src/workflow/package-loader.ts
+++ b/packages/coding-agent/src/workflow/package-loader.ts
@@ -446,6 +446,8 @@ function workflowNodeToRawRecord(node: WorkflowNode): Record<string, unknown> {
 	if (node.reads !== undefined) raw.reads = [...node.reads];
 	if (node.writes !== undefined) raw.writes = [...node.writes];
 	if (node.waitFor !== undefined) raw.waitFor = [...node.waitFor];
+	if (node.foreach !== undefined) raw.foreach = structuredClone(node.foreach);
+	if (node.workflow !== undefined) raw.workflow = structuredClone(node.workflow);
 	return raw;
 }
 

--- a/packages/coding-agent/src/workflow/patches.ts
+++ b/packages/coding-agent/src/workflow/patches.ts
@@ -521,7 +521,16 @@ function validateNodeShape(node: WorkflowNode): void {
 }
 
 function validateNodeType(type: WorkflowNodeType): void {
-	if (type === "agent" || type === "script" || type === "human" || type === "review") return;
+	if (
+		type === "agent" ||
+		type === "script" ||
+		type === "human" ||
+		type === "review" ||
+		type === "foreach" ||
+		type === "workflow"
+	) {
+		return;
+	}
 	throw new WorkflowGraphPatchError(`workflow graph patch node type is invalid: ${String(type)}`);
 }
 

--- a/packages/coding-agent/src/workflow/runner.ts
+++ b/packages/coding-agent/src/workflow/runner.ts
@@ -386,6 +386,7 @@ async function executeAndPersistActivation(
 					completedActivations: context.completedActivations,
 				},
 				resourceDir,
+				workflowBasePath: options.definition.sourcePath,
 			}),
 			executionSignal,
 		);

--- a/packages/coding-agent/src/workflow/runtime-binding.ts
+++ b/packages/coding-agent/src/workflow/runtime-binding.ts
@@ -46,6 +46,11 @@ function workflowNodeRuntimeCapabilities(node: WorkflowNode): string[] {
 	if (node.type === "human") return ["tool:ask"];
 	if (node.type === "agent") return ["tool:task", ...(node.agent ? [`agent:${node.agent}`] : [])];
 	if (node.type === "review") return ["tool:task", ...(node.agent ? [`agent:${node.agent}`] : [])];
+	if (node.type === "workflow") return ["tool:workflow"];
+	if (node.type === "foreach") {
+		if (node.foreach?.body.kind === "workflow") return ["tool:workflow"];
+		if (node.foreach?.body.kind === "node") return workflowNodeRuntimeCapabilities(node.foreach.body.node);
+	}
 	return [];
 }
 

--- a/packages/coding-agent/src/workflow/session-runtime.ts
+++ b/packages/coding-agent/src/workflow/session-runtime.ts
@@ -1,7 +1,13 @@
 import { workflowAgentTaskIdForNode } from "./agent-task-id";
 import type { WorkflowScriptLanguage } from "./definition";
 import { formatWorkflowAgentWorkItemLabel } from "./display";
-import type { WorkflowNodeRuntimeHost, WorkflowReviewNodeOutput, WorkflowScriptContext } from "./node-runtime";
+import type {
+	WorkflowNodeRuntimeHost,
+	WorkflowReviewNodeOutput,
+	WorkflowScriptContext,
+	WorkflowWorkflowNodeInput,
+	WorkflowWorkflowNodeOutput,
+} from "./node-runtime";
 import { WorkflowNodeRuntimeError } from "./node-runtime";
 import {
 	DEFAULT_WORKFLOW_MAX_SUMMARY_BYTES,
@@ -19,6 +25,7 @@ export interface WorkflowSessionRuntimeOptions {
 	runShellScript?: WorkflowShellScriptRunner;
 	runAgentTask?: WorkflowAgentTaskRunner;
 	runHumanInput?: WorkflowHumanInputRunner;
+	runChildWorkflow?: WorkflowChildWorkflowRunner;
 }
 
 export interface WorkflowAgentTaskRetryPolicy {
@@ -107,6 +114,23 @@ export interface WorkflowHumanInputResult {
 }
 
 export type WorkflowHumanInputRunner = (request: WorkflowHumanInputRequest) => Promise<WorkflowHumanInputResult>;
+
+export interface WorkflowChildWorkflowRequest {
+	activationId: string;
+	nodeId: string;
+	workflowPath: string;
+	state: Record<string, unknown>;
+	workflowBasePath?: string;
+	item?: unknown;
+	itemKey?: string;
+	itemIndex?: number;
+	parentNodeId?: string;
+	signal?: AbortSignal;
+}
+
+export type WorkflowChildWorkflowRunner = (
+	request: WorkflowChildWorkflowRequest,
+) => Promise<WorkflowWorkflowNodeOutput>;
 
 export function createSessionWorkflowRuntimeHost(options: WorkflowSessionRuntimeOptions): WorkflowNodeRuntimeHost {
 	return {
@@ -202,7 +226,31 @@ export function createSessionWorkflowRuntimeHost(options: WorkflowSessionRuntime
 			const result = await runAgentTaskWithTransientRetry(options, request);
 			return reviewOutputFromTaskResult(input.node.id, result, input.gates, input.fallbackVerdict);
 		},
+		runWorkflowNode: async input => {
+			if (!options.runChildWorkflow) {
+				throw new WorkflowNodeRuntimeError(
+					`workflow child node "${input.node.id}" requires a child workflow runtime adapter`,
+				);
+			}
+			return options.runChildWorkflow(childWorkflowRequestFromInput(input));
+		},
 	};
+}
+
+function childWorkflowRequestFromInput(input: WorkflowWorkflowNodeInput): WorkflowChildWorkflowRequest {
+	const request: WorkflowChildWorkflowRequest = {
+		activationId: input.activation.id,
+		nodeId: input.node.id,
+		workflowPath: input.workflowPath,
+		state: input.state,
+	};
+	if (input.workflowBasePath !== undefined) request.workflowBasePath = input.workflowBasePath;
+	if (input.item !== undefined) request.item = input.item;
+	if (input.itemKey !== undefined) request.itemKey = input.itemKey;
+	if (input.itemIndex !== undefined) request.itemIndex = input.itemIndex;
+	if (input.parentNodeId !== undefined) request.parentNodeId = input.parentNodeId;
+	if (input.signal !== undefined) request.signal = input.signal;
+	return request;
 }
 
 interface NormalizedWorkflowAgentTaskRetryPolicy {

--- a/packages/coding-agent/test/workflow/artifact-freeze.test.ts
+++ b/packages/coding-agent/test/workflow/artifact-freeze.test.ts
@@ -602,6 +602,76 @@ edges: []
 		);
 	});
 
+	it("captures dynamic foreach and child workflow metadata in static checks", async () => {
+		const dir = await createTempDir();
+		await fs.mkdir(path.join(dir, "release"), { recursive: true });
+		const childPath = path.join(dir, "child.omhflow");
+		await Bun.write(
+			childPath,
+			omhflowSource(`
+nodes:
+  child:
+    type: script
+    script:
+      inline: |
+        return { summary: "child" };
+edges: []
+`),
+		);
+		const flowPath = path.join(dir, "release.omhflow");
+		await Bun.write(
+			flowPath,
+			omhflowSource(`
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: /tasks
+      key: /id
+      output:
+        path: /childRuns
+      body:
+        workflow:
+          path: ./child.omhflow
+edges: []
+`),
+		);
+
+		const artifact = await loadWorkflowArtifact(flowPath);
+		const freeze = await freezeWorkflowArtifact(artifact);
+
+		expect(freeze.staticCheckReport.checks).toContainEqual({
+			name: "dynamic-topology",
+			status: "passed",
+			details: ["foreach fanout reads /tasks -> /childRuns", "child workflow fanout -> ./child.omhflow"],
+		});
+		expect(freeze.childWorkflowHashes?.map(hash => hash.path)).toEqual(["child.omhflow"]);
+		expect(freeze.childWorkflowHashes?.[0]?.hash).toMatch(/^sha256:/u);
+	});
+
+	it("rejects missing child workflow files before production freeze", async () => {
+		const dir = await createTempDir();
+		await fs.mkdir(path.join(dir, "release"), { recursive: true });
+		const flowPath = path.join(dir, "release.omhflow");
+		await Bun.write(
+			flowPath,
+			omhflowSource(`
+nodes:
+  invokeChild:
+    type: workflow
+    workflow:
+      path: ./missing-child.omhflow
+edges: []
+`),
+		);
+
+		const artifact = await loadWorkflowArtifact(flowPath);
+
+		await expect(freezeWorkflowArtifact(artifact)).rejects.toThrow(
+			'workflow child node "invokeChild" references unreadable child flow "./missing-child.omhflow"',
+		);
+	});
+
 	it("rejects pure script loops before production freeze", async () => {
 		const dir = await createTempDir();
 		await fs.mkdir(path.join(dir, "release"), { recursive: true });

--- a/packages/coding-agent/test/workflow/definition.test.ts
+++ b/packages/coding-agent/test/workflow/definition.test.ts
@@ -141,6 +141,153 @@ edges: []
 		});
 	});
 
+	it("parses dynamic foreach and child workflow nodes without expanding item branches", () => {
+		const definition = parseWorkflowDefinition(
+			`
+name: dynamic-fanout
+version: 1
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: /tasks
+      itemName: task
+      key: /id
+      concurrency: 2
+      failureMode: allSettled
+      output:
+        path: /taskResults
+      body:
+        node:
+          id: processTask
+          type: script
+          script:
+            inline: |
+              return { summary: "processed" };
+  invokeChild:
+    type: workflow
+    workflow:
+      path: ./child.omhflow
+edges:
+  - from: fanout
+    to: invokeChild
+`,
+			{ sourcePath: "dynamic.yml" },
+		);
+
+		expect(definition.nodes).toHaveLength(2);
+		expect(definition.nodes[0]).toMatchObject({
+			id: "fanout",
+			type: "foreach",
+			writes: ["/taskResults"],
+			foreach: {
+				items: "/tasks",
+				itemName: "task",
+				key: "/id",
+				concurrency: 2,
+				failureMode: "allSettled",
+				output: { path: "/taskResults" },
+				body: {
+					kind: "node",
+					node: {
+						id: "processTask",
+						type: "script",
+						script: { code: 'return { summary: "processed" };\n' },
+					},
+				},
+			},
+		});
+		expect(definition.nodes[1]).toMatchObject({
+			id: "invokeChild",
+			type: "workflow",
+			workflow: { path: "./child.omhflow" },
+		});
+		expect(definition.edges.map(edge => [edge.from, edge.to])).toEqual([["fanout", "invokeChild"]]);
+	});
+
+	it("rejects foreach item and output paths that are not JSON pointers", () => {
+		expect(() =>
+			parseWorkflowDefinition(
+				`
+name: invalid-foreach
+version: 1
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: tasks
+      output:
+        path: /results
+      body:
+        node:
+          id: processTask
+          type: script
+          script:
+            inline: |
+              return { summary: "processed" };
+edges: []
+`,
+				{ sourcePath: "dynamic.yml" },
+			),
+		).toThrow("dynamic.yml: nodes.fanout.foreach.items must be a JSON pointer");
+		expect(() =>
+			parseWorkflowDefinition(
+				`
+name: invalid-foreach-output
+version: 1
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: /tasks
+      output:
+        path: results
+      body:
+        node:
+          id: processTask
+          type: script
+          script:
+            inline: |
+              return { summary: "processed" };
+edges: []
+`,
+				{ sourcePath: "dynamic.yml" },
+			),
+		).toThrow("dynamic.yml: nodes.fanout.foreach.output.path must be a JSON pointer");
+	});
+
+	it("accepts foreach body as an inline node object", () => {
+		const definition = parseWorkflowDefinition(
+			`
+name: inline-foreach-body
+version: 1
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: /tasks
+      output:
+        path: /results
+      body:
+        id: processTask
+        type: script
+        script:
+          inline: |
+            return { summary: "processed" };
+edges: []
+`,
+			{ sourcePath: "dynamic.yml" },
+		);
+
+		expect(definition.nodes[0]?.foreach?.body).toMatchObject({
+			kind: "node",
+			node: {
+				id: "processTask",
+				type: "script",
+			},
+		});
+	});
+
 	it("rejects script node runtime budgets outside the supported adapter limit", () => {
 		const source = `
 name: invalid-script-timeout

--- a/packages/coding-agent/test/workflow/dsl-compiler.test.ts
+++ b/packages/coding-agent/test/workflow/dsl-compiler.test.ts
@@ -118,6 +118,96 @@ use: loop
 		await expect(loadWorkflowArtifact(flowPath)).rejects.toThrow('modules.loop.use creates a module cycle at "loop"');
 	});
 
+	it("compiles foreach as one dynamic node without static branch expansion", async () => {
+		const dir = await createTempDir();
+		await fs.mkdir(path.join(dir, "dynamic"), { recursive: true });
+		const flowPath = path.join(dir, "dynamic.omhflow");
+		await Bun.write(
+			flowPath,
+			flowSource(`
+sequence:
+  - foreach:
+      id: fanout
+      items: /tasks
+      itemName: task
+      key: /id
+      concurrency: 3
+      failureMode: allSettled
+      output:
+        path: /taskResults
+      body:
+        node:
+          id: processTask
+          type: script
+          script:
+            inline: |
+              return { summary: "processed" };
+  - node:
+      id: summarize
+      type: script
+      script:
+        inline: |
+          return { summary: "summarized" };
+`),
+		);
+
+		const artifact = await loadWorkflowArtifact(flowPath);
+
+		expect(artifact.entryNodeIds).toEqual(["fanout"]);
+		expect(artifact.definition.nodes.map(node => [node.id, node.type])).toEqual([
+			["fanout", "foreach"],
+			["summarize", "script"],
+		]);
+		expect(artifact.definition.edges.map(edge => [edge.from, edge.to])).toEqual([["fanout", "summarize"]]);
+		expect(artifact.definition.nodes[0]).toMatchObject({
+			foreach: {
+				items: "/tasks",
+				itemName: "task",
+				key: "/id",
+				concurrency: 3,
+				failureMode: "allSettled",
+				output: { path: "/taskResults" },
+				body: {
+					kind: "node",
+					node: { id: "processTask", type: "script" },
+				},
+			},
+		});
+	});
+
+	it("compiles foreach child workflow bodies as dynamic invocations", async () => {
+		const dir = await createTempDir();
+		await fs.mkdir(path.join(dir, "dynamic-child"), { recursive: true });
+		const flowPath = path.join(dir, "dynamic-child.omhflow");
+		await Bun.write(
+			flowPath,
+			flowSource(`
+foreach:
+  id: fanout
+  items: /tasks
+  output:
+    path: /childRuns
+  body:
+    workflow:
+      path: ./child.omhflow
+`),
+		);
+
+		const artifact = await loadWorkflowArtifact(flowPath);
+
+		expect(artifact.definition.nodes).toHaveLength(1);
+		expect(artifact.definition.nodes[0]).toMatchObject({
+			id: "fanout",
+			type: "foreach",
+			foreach: {
+				body: {
+					kind: "workflow",
+					workflow: { path: "./child.omhflow" },
+				},
+			},
+		});
+	});
+
 	it("rejects artifacts with multiple workflow blocks", async () => {
 		const dir = await createTempDir();
 		await fs.mkdir(path.join(dir, "multi"), { recursive: true });

--- a/packages/coding-agent/test/workflow/graph-view.test.ts
+++ b/packages/coding-agent/test/workflow/graph-view.test.ts
@@ -541,6 +541,54 @@ describe("workflow graph view rendering", () => {
 		);
 	});
 
+	it("summarizes dynamic foreach fan-outs and child workflow links without item expansion", () => {
+		const view = createView({
+			name: "dynamic-topology",
+			version: 1,
+			models: { roles: {}, defaults: {} },
+			nodes: [
+				{
+					id: "fanout",
+					type: "foreach",
+					foreach: {
+						items: "/tasks",
+						key: "/id",
+						concurrency: 2,
+						failureMode: "allSettled",
+						output: { path: "/childRuns" },
+						body: {
+							kind: "workflow",
+							workflow: { path: "./child.omhflow" },
+						},
+					},
+				},
+			],
+			edges: [],
+		});
+
+		expect(view.nodes).toHaveLength(1);
+		expect(view.nodes[0]).toMatchObject({
+			id: "fanout",
+			kind: "foreach",
+		});
+		expect(view.topology).toMatchObject({
+			dynamicFanOuts: 1,
+			childWorkflows: 1,
+		});
+		expect(view.childWorkflows).toEqual([
+			{
+				nodeId: "fanout",
+				path: "./child.omhflow",
+				withinForeach: true,
+			},
+		]);
+		const text = renderWorkflowGraphText(view);
+		expect(text).toContain("Flow: dynamic fan-outs 1 / child workflows 1 · 1 node");
+		expect(text).toContain("Child workflows:");
+		expect(text).toContain("- fanout foreach invokes ./child.omhflow");
+		expect(text).not.toContain("processTask");
+	});
+
 	it("describes multiple root nodes as parallel roots instead of linear flow", () => {
 		const view = createView({
 			name: "parallel-roots",

--- a/packages/coding-agent/test/workflow/patches.test.ts
+++ b/packages/coding-agent/test/workflow/patches.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { parseWorkflowChangeRequestFile } from "../../src/workflow/change-request-file";
 import { parseWorkflowDefinition } from "../../src/workflow/definition";
 import {
 	applyWorkflowGraphPatch,
@@ -400,6 +401,65 @@ edges:
 					activation: "latest-completed",
 				},
 				after: { kind: "inline", text: "Use the static fallback plan." },
+			},
+		]);
+	});
+
+	it("preserves foreach and child workflow metadata in change request nodes", () => {
+		const request = parseWorkflowChangeRequestFile(
+			{
+				operations: [
+					{
+						op: "add_node",
+						node: {
+							id: "fanout",
+							type: "foreach",
+							foreach: {
+								items: "/pullRequests",
+								key: "/number",
+								concurrency: 3,
+								failureMode: "allSettled",
+								output: { path: "/reviewResults" },
+								body: { workflow: { path: "./pr-review.omhflow" } },
+							},
+						},
+					},
+					{
+						op: "add_node",
+						node: {
+							id: "invokeChild",
+							type: "workflow",
+							workflow: { path: "./child.omhflow" },
+						},
+					},
+				],
+			},
+			"change.json",
+		);
+
+		expect(request.operations).toEqual([
+			{
+				op: "add_node",
+				node: {
+					id: "fanout",
+					type: "foreach",
+					foreach: {
+						items: "/pullRequests",
+						key: "/number",
+						concurrency: 3,
+						failureMode: "allSettled",
+						output: { path: "/reviewResults" },
+						body: { kind: "workflow", workflow: { path: "./pr-review.omhflow" } },
+					},
+				},
+			},
+			{
+				op: "add_node",
+				node: {
+					id: "invokeChild",
+					type: "workflow",
+					workflow: { path: "./child.omhflow" },
+				},
 			},
 		]);
 	});

--- a/packages/coding-agent/test/workflow/runner.test.ts
+++ b/packages/coding-agent/test/workflow/runner.test.ts
@@ -140,6 +140,33 @@ function isStatePatchEvent(data: unknown): boolean {
 	return isRecord(data) && data.event === "state_patch_applied";
 }
 
+interface TestTask {
+	id: string;
+	value?: number;
+}
+
+function taskFromState(input: WorkflowScriptNodeInput): TestTask {
+	const state = input.context?.state;
+	const task = isRecord(state) ? state.task : undefined;
+	if (!isRecord(task) || typeof task.id !== "string") {
+		throw new Error("expected foreach item state at task.id");
+	}
+	const result: TestTask = { id: task.id };
+	if (typeof task.value === "number") result.value = task.value;
+	return result;
+}
+
+function itemFromState(input: WorkflowScriptNodeInput): TestTask {
+	const state = input.context?.state;
+	const item = isRecord(state) ? state.item : undefined;
+	if (!isRecord(item) || typeof item.id !== "string") {
+		throw new Error("expected foreach item state at item.id");
+	}
+	const result: TestTask = { id: item.id };
+	if (typeof item.value === "number") result.value = item.value;
+	return result;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -276,6 +303,432 @@ edges: []
 				verdict: "done",
 			},
 		);
+	});
+
+	it("runs foreach item bodies with bounded concurrency and deterministic records", async () => {
+		const host = createHost();
+		const definition = parseWorkflowDefinition(
+			`
+name: foreach-runner
+version: 1
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: /tasks
+      itemName: task
+      key: /id
+      concurrency: 2
+      failureMode: allSettled
+      output:
+        path: /taskResults
+      body:
+        node:
+          id: processTask
+          type: script
+          script:
+            inline: |
+              return { summary: "processed" };
+edges: []
+`,
+			{ sourcePath: "workflow.yml" },
+		);
+		const firstStarted = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<void>();
+		const thirdStarted = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const releaseSecond = Promise.withResolvers<void>();
+		const startedKeys: string[] = [];
+		let active = 0;
+		let maxActive = 0;
+		const runtimeHost: WorkflowNodeRuntimeHost = {
+			runScriptNode: async input => {
+				const task = taskFromState(input);
+				startedKeys.push(task.id);
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				if (task.id === "a") {
+					firstStarted.resolve();
+					await releaseFirst.promise;
+				}
+				if (task.id === "b") {
+					secondStarted.resolve();
+					await releaseSecond.promise;
+				}
+				if (task.id === "c") thirdStarted.resolve();
+				active -= 1;
+				return {
+					summary: `processed ${task.id}`,
+					data: { value: task.value },
+					artifacts: [`artifact://workflow/${task.id}.json`],
+				};
+			},
+		};
+
+		const runPromise = runWorkflow({
+			host,
+			definition,
+			runId: "foreach-runner",
+			startNodeId: "fanout",
+			runtimeHost,
+			initialState: {
+				tasks: [
+					{ id: "a", value: 1 },
+					{ id: "b", value: 2 },
+					{ id: "c", value: 3 },
+				],
+			},
+		});
+		await firstStarted.promise;
+		await secondStarted.promise;
+		const thirdBeforeRelease = await Promise.race([
+			thirdStarted.promise.then(() => "third-started"),
+			Bun.sleep(20).then(() => "blocked"),
+		]);
+		releaseFirst.resolve();
+		releaseSecond.resolve();
+		const result = await runPromise;
+
+		expect(thirdBeforeRelease).toBe("blocked");
+		expect(startedKeys).toEqual(["a", "b", "c"]);
+		expect(maxActive).toBe(2);
+		expect(result.scheduler.activations.map(activation => [activation.nodeId, activation.status])).toEqual([
+			["fanout", "completed"],
+		]);
+		expect(result.scheduler.state.taskResults).toEqual({
+			records: [
+				{
+					key: "a",
+					index: 0,
+					status: "completed",
+					summary: "processed a",
+					data: { value: 1 },
+					artifacts: ["artifact://workflow/a.json"],
+				},
+				{
+					key: "b",
+					index: 1,
+					status: "completed",
+					summary: "processed b",
+					data: { value: 2 },
+					artifacts: ["artifact://workflow/b.json"],
+				},
+				{
+					key: "c",
+					index: 2,
+					status: "completed",
+					summary: "processed c",
+					data: { value: 3 },
+					artifacts: ["artifact://workflow/c.json"],
+				},
+			],
+			lifecycle: {
+				queuedKeys: [],
+				runningKeys: [],
+				completedKeys: ["a", "b", "c"],
+				failedKeys: [],
+				abortedKeys: [],
+			},
+		});
+	});
+
+	it("keeps foreach allSettled records when an item body fails", async () => {
+		const host = createHost();
+		const definition = parseWorkflowDefinition(
+			`
+name: foreach-all-settled
+version: 1
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: /tasks
+      key: /id
+      failureMode: allSettled
+      output:
+        path: /taskResults
+      body:
+        node:
+          id: processTask
+          type: script
+          script:
+            inline: |
+              return { summary: "processed" };
+edges: []
+`,
+			{ sourcePath: "workflow.yml" },
+		);
+		const runtimeHost: WorkflowNodeRuntimeHost = {
+			runScriptNode: async input => {
+				const task = itemFromState(input);
+				if (task.id === "b") throw new Error("task b failed");
+				return { summary: `processed ${task.id}`, data: { id: task.id } };
+			},
+		};
+
+		const result = await runWorkflow({
+			host,
+			definition,
+			runId: "foreach-all-settled",
+			startNodeId: "fanout",
+			runtimeHost,
+			initialState: { tasks: [{ id: "a" }, { id: "b" }, { id: "c" }] },
+		});
+
+		expect(result.scheduler.activations.map(activation => [activation.nodeId, activation.status])).toEqual([
+			["fanout", "completed"],
+		]);
+		expect(result.scheduler.state.taskResults).toMatchObject({
+			records: [
+				{ key: "a", index: 0, status: "completed" },
+				{ key: "b", index: 1, status: "failed", error: "task b failed" },
+				{ key: "c", index: 2, status: "completed" },
+			],
+			lifecycle: {
+				completedKeys: ["a", "c"],
+				failedKeys: ["b"],
+			},
+		});
+	});
+
+	it("fails foreach failFast activations on the first item failure", async () => {
+		const host = createHost();
+		const definition = parseWorkflowDefinition(
+			`
+name: foreach-fail-fast
+version: 1
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: /tasks
+      key: /id
+      failureMode: failFast
+      output:
+        path: /taskResults
+      body:
+        node:
+          id: processTask
+          type: script
+          script:
+            inline: |
+              return { summary: "processed" };
+edges: []
+`,
+			{ sourcePath: "workflow.yml" },
+		);
+		const runtimeHost: WorkflowNodeRuntimeHost = {
+			runScriptNode: async input => {
+				const task = itemFromState(input);
+				if (task.id === "b") throw new Error("task b failed");
+				return { summary: `processed ${task.id}` };
+			},
+		};
+
+		const result = await runWorkflow({
+			host,
+			definition,
+			runId: "foreach-fail-fast",
+			startNodeId: "fanout",
+			runtimeHost,
+			initialState: { tasks: [{ id: "a" }, { id: "b" }, { id: "c" }] },
+		});
+
+		expect(result.scheduler.activations.map(activation => [activation.nodeId, activation.status])).toEqual([
+			["fanout", "failed"],
+		]);
+		expect(result.scheduler.activations[0]?.error).toBe('foreach node "fanout" item "b" failed: task b failed');
+		expect(result.scheduler.state).toEqual({
+			tasks: [{ id: "a" }, { id: "b" }, { id: "c" }],
+		});
+	});
+
+	it("maps child workflow invocation refs into foreach item records", async () => {
+		const host = createHost();
+		const definition = parseWorkflowDefinition(
+			`
+name: foreach-child
+version: 1
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: /tasks
+      key: /id
+      output:
+        path: /childRuns
+      body:
+        workflow:
+          path: ./child.omhflow
+edges: []
+`,
+			{ sourcePath: "workflow.yml" },
+		);
+		const runtimeHost: WorkflowNodeRuntimeHost = {
+			runWorkflowNode: async input => ({
+				summary: `child ${input.itemKey}`,
+				data: { accepted: true },
+				childFamilyId: `family-${input.itemKey}`,
+				childAttemptId: `attempt-${input.itemKey}`,
+			}),
+		};
+
+		const result = await runWorkflow({
+			host,
+			definition,
+			runId: "foreach-child",
+			startNodeId: "fanout",
+			runtimeHost,
+			initialState: { tasks: [{ id: "a" }, { id: "b" }] },
+		});
+
+		expect(result.scheduler.state.childRuns).toEqual({
+			records: [
+				{
+					key: "a",
+					index: 0,
+					status: "completed",
+					summary: "child a",
+					data: { accepted: true },
+					childFamilyId: "family-a",
+					childAttemptId: "attempt-a",
+				},
+				{
+					key: "b",
+					index: 1,
+					status: "completed",
+					summary: "child b",
+					data: { accepted: true },
+					childFamilyId: "family-b",
+					childAttemptId: "attempt-b",
+				},
+			],
+			lifecycle: {
+				queuedKeys: [],
+				runningKeys: [],
+				completedKeys: ["a", "b"],
+				failedKeys: [],
+				abortedKeys: [],
+			},
+		});
+	});
+
+	it("runs child workflow invocation nodes through the runtime host seam", async () => {
+		const host = createHost();
+		const definition = parseWorkflowDefinition(
+			`
+name: child-node
+version: 1
+nodes:
+  invokeChild:
+    type: workflow
+    workflow:
+      path: ./child.omhflow
+edges: []
+`,
+			{ sourcePath: "workflow.yml" },
+		);
+		const receivedPaths: string[] = [];
+		const runtimeHost: WorkflowNodeRuntimeHost = {
+			runWorkflowNode: async input => {
+				receivedPaths.push(input.workflowPath);
+				return {
+					summary: "child completed",
+					data: { result: "ok" },
+					childFamilyId: "family-child",
+					childAttemptId: "attempt-child-1",
+				};
+			},
+		};
+
+		const result = await runWorkflow({
+			host,
+			definition,
+			runId: "child-node",
+			startNodeId: "invokeChild",
+			runtimeHost,
+		});
+
+		expect(receivedPaths).toEqual(["./child.omhflow"]);
+		expect(result.scheduler.activations.map(activation => [activation.nodeId, activation.status])).toEqual([
+			["invokeChild", "completed"],
+		]);
+		expect(result.scheduler.activations[0]?.output).toEqual({
+			summary: "child completed",
+			data: {
+				result: "ok",
+				childFamilyId: "family-child",
+				childAttemptId: "attempt-child-1",
+			},
+		});
+	});
+
+	it("preserves foreach lifecycle keys when parent cancellation aborts queued item work", async () => {
+		const host = createHost();
+		const controller = new AbortController();
+		const definition = parseWorkflowDefinition(
+			`
+name: foreach-abort
+version: 1
+nodes:
+  fanout:
+    type: foreach
+    foreach:
+      items: /tasks
+      key: /id
+      concurrency: 1
+      failureMode: allSettled
+      output:
+        path: /taskResults
+      body:
+        node:
+          id: processTask
+          type: script
+          script:
+            inline: |
+              return { summary: "processed" };
+edges: []
+`,
+			{ sourcePath: "workflow.yml" },
+		);
+		const runtimeHost: WorkflowNodeRuntimeHost = {
+			runScriptNode: async input => {
+				const task = itemFromState(input);
+				if (task.id === "b") {
+					controller.abort("operator stopped foreach");
+					throw new Error("operator stopped foreach");
+				}
+				return { summary: `processed ${task.id}` };
+			},
+		};
+
+		const result = await runWorkflow({
+			host,
+			definition,
+			runId: "foreach-abort",
+			startNodeId: "fanout",
+			runtimeHost,
+			initialState: { tasks: [{ id: "a" }, { id: "b" }, { id: "c" }] },
+			signal: controller.signal,
+		});
+
+		expect(result.scheduler.activations.map(activation => [activation.nodeId, activation.status])).toEqual([
+			["fanout", "completed"],
+		]);
+		expect(result.scheduler.state.taskResults).toMatchObject({
+			records: [
+				{ key: "a", index: 0, status: "completed" },
+				{ key: "b", index: 1, status: "aborted", error: "operator stopped foreach" },
+				{ key: "c", index: 2, status: "queued" },
+			],
+			lifecycle: {
+				queuedKeys: ["c"],
+				runningKeys: [],
+				completedKeys: ["a"],
+				failedKeys: [],
+				abortedKeys: ["b"],
+			},
+		});
 	});
 
 	it("checkpoints frozen attempts that stop at the activation limit", async () => {


### PR DESCRIPTION
## Summary
- Adds first-class `foreach` workflow nodes with bounded concurrency, stable item keys, allSettled/failFast/continueOnError modes, deterministic item aggregation, and checkpoint-visible lifecycle keys.
- Adds first-class child `.omhflow` invocation nodes plus a runtime host seam and headless CLI child-run implementation that links child family/attempt ids back to parent outputs.
- Extends DSL parsing, definition validation, freeze metadata, graph/TUI summary metadata, runtime binding checks, change-request parsing, examples, and regression tests.

Closes #2.

## Verification
- `bun test packages/coding-agent/src/cli/__tests__/workflow-cli.test.ts packages/coding-agent/test/workflow/patches.test.ts packages/coding-agent/test/workflow/runner.test.ts packages/coding-agent/test/workflow/definition.test.ts packages/coding-agent/test/workflow/artifact-freeze.test.ts packages/coding-agent/test/workflow/dsl-compiler.test.ts packages/coding-agent/test/workflow/graph-view.test.ts packages/coding-agent/src/workflow/__tests__/session-runtime.test.ts packages/coding-agent/src/workflow/graph-view.test.ts packages/coding-agent/src/slash-commands/helpers/workflow-help.test.ts packages/coding-agent/src/modes/components/workflow-graph.test.ts`
- `bun --cwd=packages/coding-agent run check`

Known pre-existing failures, reproduced on main: `packages/coding-agent/test/workflow-command.test.ts` expects an `omp` help example while the current help uses `omh`, and `packages/coding-agent/test/workflow/reference-flow-replicas.test.ts` fails resolving the KDA prompt template binding `plan`.