### PR TITLE
feat: add Codex device-code login option

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Codex device-code login to follow the official headless flow with the injected fetch client, usercode response alias support, and immediate token polling.
+
 ## [16.2.5] - 2026-06-28
 
 ### Fixed

--- a/packages/ai/src/registry/oauth/openai-codex.ts
+++ b/packages/ai/src/registry/oauth/openai-codex.ts
@@ -23,10 +23,9 @@ const DEVICE_USERCODE_URL = "https://auth.openai.com/api/accounts/deviceauth/use
 const DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token";
 const DEVICE_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback";
 const DEVICE_AUTH_URL = "https://auth.openai.com/codex/device";
-const DEVICE_POLL_INTERVAL_MS = 5_000;
-const DEVICE_POLL_SAFETY_MARGIN_MS = 3_000;
-/** Upper bound on device-code polling to avoid infinite loops on server errors. */
-const DEVICE_MAX_POLLS = 120;
+const DEVICE_DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEVICE_MIN_POLL_INTERVAL_MS = 1_000;
+const DEVICE_MAX_WAIT_MS = 15 * 60_000;
 
 type JwtPayload = {
 	[JWT_CLAIM_PATH]?: {
@@ -64,6 +63,48 @@ function getTokenProfile(accessToken: string): { accountId?: string; email?: str
 interface PKCE {
 	verifier: string;
 	challenge: string;
+}
+
+function timeoutSignal(ctrlSignal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+	const timeout = AbortSignal.timeout(timeoutMs);
+	return ctrlSignal ? AbortSignal.any([ctrlSignal, timeout]) : timeout;
+}
+
+function parseDevicePollIntervalMs(value: string | number | undefined): number {
+	let seconds: number | undefined;
+	if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+		seconds = value;
+	} else if (typeof value === "string") {
+		const parsed = Number(value.trim());
+		if (Number.isFinite(parsed) && parsed >= 0) seconds = parsed;
+	}
+	return seconds === undefined
+		? DEVICE_DEFAULT_POLL_INTERVAL_MS
+		: Math.max(DEVICE_MIN_POLL_INTERVAL_MS, seconds * 1000);
+}
+
+async function sleepDevicePoll(ms: number, signal: AbortSignal | undefined): Promise<void> {
+	if (ms <= 0) return;
+	if (!signal) {
+		await Bun.sleep(ms);
+		return;
+	}
+	if (signal.aborted) {
+		throw new AIError.LoginCancelledError("Device authorization cancelled");
+	}
+
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	let timer: Timer | undefined;
+	const onAbort = () => {
+		clearTimeout(timer);
+		reject(new AIError.LoginCancelledError("Device authorization cancelled"));
+	};
+	timer = setTimeout(() => {
+		signal.removeEventListener("abort", onAbort);
+		resolve();
+	}, ms);
+	signal.addEventListener("abort", onAbort, { once: true });
+	await promise;
 }
 function describeTokenEndpointValue(value: unknown): string | undefined {
 	if (typeof value === "string") {
@@ -231,11 +272,12 @@ export async function loginOpenAICodex(options: OpenAICodexLoginOptions): Promis
 export async function loginOpenAICodexDevice(ctrl: OAuthController): Promise<OAuthCredentials> {
 	ctrl.onProgress?.("Initiating device authorization…");
 
-	const initResponse = await fetch(DEVICE_USERCODE_URL, {
+	const fetchImpl = ctrl.fetch ?? fetch;
+	const initResponse = await fetchImpl(DEVICE_USERCODE_URL, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ client_id: CLIENT_ID }),
-		signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+		signal: timeoutSignal(ctrl.signal, TOKEN_REQUEST_TIMEOUT_MS),
 	});
 
 	if (!initResponse.ok) {
@@ -248,20 +290,16 @@ export async function loginOpenAICodexDevice(ctrl: OAuthController): Promise<OAu
 	const initData = (await initResponse.json()) as {
 		device_auth_id?: string;
 		user_code?: string;
+		usercode?: string;
 		interval?: string | number;
 	};
+	const userCode = initData.user_code ?? initData.usercode;
 
-	if (!initData.device_auth_id || !initData.user_code) {
+	if (!initData.device_auth_id || !userCode) {
 		throw new AIError.OAuthError("Device authorization response missing required fields", { kind: "validation" });
 	}
 
-	const userCode = initData.user_code;
-	const pollIntervalMs =
-		(typeof initData.interval === "number"
-			? initData.interval
-			: parseInt(String(initData.interval ?? "5"), 10) || 5) *
-			1000 +
-		DEVICE_POLL_SAFETY_MARGIN_MS;
+	const pollIntervalMs = parseDevicePollIntervalMs(initData.interval);
 
 	ctrl.onAuth?.({
 		url: DEVICE_AUTH_URL,
@@ -270,24 +308,29 @@ export async function loginOpenAICodexDevice(ctrl: OAuthController): Promise<OAu
 
 	ctrl.onProgress?.(`Waiting for browser authorization (code: ${userCode})…`);
 
-	for (let poll = 0; poll < DEVICE_MAX_POLLS; poll++) {
-		await Bun.sleep(poll === 0 ? Math.min(pollIntervalMs, DEVICE_POLL_INTERVAL_MS) : pollIntervalMs);
+	const deadlineMs = Date.now() + DEVICE_MAX_WAIT_MS;
+	let firstPoll = true;
+	while (Date.now() < deadlineMs) {
+		if (!firstPoll) {
+			await sleepDevicePoll(Math.min(pollIntervalMs, Math.max(0, deadlineMs - Date.now())), ctrl.signal);
+		}
+		firstPoll = false;
 
 		if (ctrl.signal?.aborted) {
 			throw new AIError.LoginCancelledError("Device authorization cancelled");
 		}
 
-		const pollResponse = await fetch(DEVICE_TOKEN_URL, {
+		const pollResponse = await fetchImpl(DEVICE_TOKEN_URL, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
 				device_auth_id: initData.device_auth_id,
 				user_code: userCode,
 			}),
-			signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+			signal: timeoutSignal(ctrl.signal, TOKEN_REQUEST_TIMEOUT_MS),
 		});
 
-		// 403/404 = authorization pending, keep polling
+		// 403/404 = authorization pending, keep polling.
 		if (pollResponse.status === 403 || pollResponse.status === 404) {
 			continue;
 		}
@@ -301,6 +344,7 @@ export async function loginOpenAICodexDevice(ctrl: OAuthController): Promise<OAu
 
 		const pollData = (await pollResponse.json()) as {
 			authorization_code?: string;
+			code_challenge?: string;
 			code_verifier?: string;
 		};
 
@@ -311,7 +355,7 @@ export async function loginOpenAICodexDevice(ctrl: OAuthController): Promise<OAu
 		}
 
 		ctrl.onProgress?.("Exchanging authorization code for tokens…");
-		return exchangeCodeForToken(pollData.authorization_code, pollData.code_verifier, DEVICE_REDIRECT_URI);
+		return exchangeCodeForToken(pollData.authorization_code, pollData.code_verifier, DEVICE_REDIRECT_URI, fetchImpl);
 	}
 
 	throw new AIError.OAuthError("Device authorization timed out — user did not complete login in time", {

--- a/packages/ai/src/registry/openai-codex-device.ts
+++ b/packages/ai/src/registry/openai-codex-device.ts
@@ -1,18 +1,11 @@
-import type { OAuthCredentials, OAuthLoginCallbacks } from "./oauth/types";
+import { loginOpenAICodexDevice, refreshOpenAICodexToken } from "./oauth/openai-codex";
+import type { OAuthCredentials } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
 
 export const openaiCodexDeviceProvider = {
 	id: "openai-codex-device",
-	name: "ChatGPT Plus/Pro (Codex, headless/device)",
-	login: async (cb: OAuthLoginCallbacks) => {
-		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
-		const { loginOpenAICodexDevice } = await import("./oauth/openai-codex");
-		return loginOpenAICodexDevice(cb);
-	},
-	refreshToken: async (credentials: OAuthCredentials) => {
-		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
-		const { refreshOpenAICodexToken } = await import("./oauth/openai-codex");
-		return refreshOpenAICodexToken(credentials.refresh);
-	},
+	name: "Codex (device code)",
+	login: loginOpenAICodexDevice,
+	refreshToken: async (credentials: OAuthCredentials) => refreshOpenAICodexToken(credentials.refresh),
 	storeCredentialsAs: "openai-codex",
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -76,6 +76,7 @@ import { zhipuCodingPlanProvider } from "./zhipu-coding-plan";
 const ALL = [
 	azureProvider,
 	openaiCodexProvider,
+	openaiCodexDeviceProvider,
 	anthropicProvider,
 	zaiProvider,
 	kimiCodeProvider,
@@ -85,7 +86,6 @@ const ALL = [
 	devinProvider,
 	googleAntigravityProvider,
 	googleGeminiCliProvider,
-	openaiCodexDeviceProvider,
 	xaiOauthProvider,
 	gitlabDuoProvider,
 	gitLabDuoWorkflowProvider,

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -2,16 +2,25 @@ import { describe, expect, it } from "bun:test";
 import {
 	createOpenAICodexAuthorizationUrl,
 	formatOpenAICodexTokenEndpointError,
+	loginOpenAICodexDevice,
 } from "@oh-my-pi/pi-ai/oauth/openai-codex";
 import { type RequestBody, transformRequestBody } from "@oh-my-pi/pi-ai/providers/openai-codex/request-transformer";
 import { CodexApiError, parseCodexError } from "@oh-my-pi/pi-ai/providers/openai-codex/response-handler";
 import { convertOpenAICodexResponsesTools } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
-import type { Tool } from "@oh-my-pi/pi-ai/types";
+import type { FetchImpl, Tool } from "@oh-my-pi/pi-ai/types";
 import { OPENAI_HEADER_VALUES } from "@oh-my-pi/pi-catalog/wire/codex";
 import { createCodexModel } from "./helpers";
 
 const DEFAULT_PROMPT_PREFIX =
 	"You are an expert coding assistant. You help users with coding tasks by reading files, executing commands";
+
+function makeCodexAccessToken(): string {
+	const payload = {
+		"https://api.openai.com/auth": { chatgpt_account_id: "acct_123" },
+		"https://api.openai.com/profile": { email: "USER@example.COM" },
+	};
+	return ["header", Buffer.from(JSON.stringify(payload)).toString("base64"), "signature"].join(".");
+}
 
 describe("openai-codex oauth", () => {
 	it("uses the same default originator for browser login and API requests", () => {
@@ -43,6 +52,67 @@ describe("openai-codex oauth", () => {
 		);
 
 		expect(detail).toBe("403 access_denied: Connector scope missing");
+	});
+
+	it("completes the official headless device-code flow without a local callback", async () => {
+		const requests: Array<{ url: string; method?: string; body: string }> = [];
+		const fetchImpl: FetchImpl = async (input, init) => {
+			const url = input instanceof Request ? input.url : input.toString();
+			const body = init?.body === undefined || init.body === null ? "" : String(init.body);
+			requests.push({ url, method: init?.method, body });
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/usercode") {
+				return Response.json({ device_auth_id: "device-1", usercode: "ABCD-1234", interval: "0" });
+			}
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/token") {
+				return Response.json({
+					authorization_code: "auth-code",
+					code_challenge: "challenge",
+					code_verifier: "verifier",
+				});
+			}
+			if (url === "https://auth.openai.com/oauth/token") {
+				return Response.json({
+					access_token: makeCodexAccessToken(),
+					refresh_token: "refresh-1",
+					expires_in: 3600,
+				});
+			}
+			return new Response(`unexpected ${url}`, { status: 500 });
+		};
+		const authEvents: Array<{ url: string; instructions?: string }> = [];
+		const progress: string[] = [];
+
+		const credentials = await loginOpenAICodexDevice({
+			fetch: fetchImpl,
+			onAuth: info => authEvents.push(info),
+			onProgress: message => progress.push(message),
+		});
+
+		expect(authEvents).toEqual([
+			{ url: "https://auth.openai.com/codex/device", instructions: "Enter code: ABCD-1234" },
+		]);
+		expect(progress).toEqual([
+			"Initiating device authorization…",
+			"Waiting for browser authorization (code: ABCD-1234)…",
+			"Exchanging authorization code for tokens…",
+		]);
+		expect(credentials.refresh).toBe("refresh-1");
+		expect(credentials.accountId).toBe("acct_123");
+		expect(credentials.email).toBe("user@example.com");
+
+		expect(requests.map(request => request.url)).toEqual([
+			"https://auth.openai.com/api/accounts/deviceauth/usercode",
+			"https://auth.openai.com/api/accounts/deviceauth/token",
+			"https://auth.openai.com/oauth/token",
+		]);
+		expect(JSON.parse(requests[0].body)).toEqual({ client_id: expect.stringMatching(/^app_/) });
+		expect(JSON.parse(requests[1].body)).toEqual({ device_auth_id: "device-1", user_code: "ABCD-1234" });
+
+		const tokenBody = new URLSearchParams(requests[2].body);
+		expect(tokenBody.get("grant_type")).toBe("authorization_code");
+		expect(tokenBody.get("code")).toBe("auth-code");
+		expect(tokenBody.get("code_verifier")).toBe("verifier");
+		expect(tokenBody.get("redirect_uri")).toBe("https://auth.openai.com/deviceauth/callback");
 	});
 });
 

--- a/packages/ai/test/provider-registry.test.ts
+++ b/packages/ai/test/provider-registry.test.ts
@@ -71,6 +71,17 @@ describe("provider registry auth surface", () => {
 		expect(ids).not.toContain("openai");
 	});
 
+	test("login list labels the Codex device-code option", () => {
+		const providers = getOAuthProviders();
+		const browserIndex = providers.findIndex(provider => provider.id === "openai-codex");
+		const deviceIndex = providers.findIndex(provider => provider.id === "openai-codex-device");
+
+		expect(browserIndex).toBeGreaterThanOrEqual(0);
+		expect(deviceIndex).toBe(browserIndex + 1);
+		expect(providers[deviceIndex]?.name).toBe("Codex (device code)");
+		expect(providers[deviceIndex]?.storeCredentialsAs).toBe("openai-codex");
+	});
+
 	test("paste-code login set is derived from pasteCodeFlow", () => {
 		expect([...PASTE_CODE_LOGIN_PROVIDERS].sort()).toEqual(
 			[

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `Codex (device code)` option to the `/login` provider selector and `omh auth-broker login --device-auth` for headless Codex subscription login, including remote SSH execution without a callback tunnel.
+
 ### Fixed
 
 - Fixed the experimental performance-optimization-search flow treating a committed positive selection with a clean worktree as a no-win outcome during finalize/archive.

--- a/packages/coding-agent/src/cli/auth-broker-cli.ts
+++ b/packages/coding-agent/src/cli/auth-broker-cli.ts
@@ -4,8 +4,8 @@
  * Sub-verbs:
  *   - `serve [--bind=…]` — boots the broker against the local SQLite store.
  *   - `token` / `token --regenerate` — manages the bearer token file.
- *   - `login <provider> [--via=user@host]` — logs into a provider locally, or
- *     via SSH tunnel into a remote broker host.
+ *   - `login <provider> [--device-auth] [--via=user@host]` — logs into a
+ *     provider locally, or via SSH tunnel/direct SSH into a remote broker host.
  *   - `import <file|dir>` — imports CLIProxyAPI-style JSON credentials into
  *     the local SQLite store (typical use: `import ~/.cliproxy/auth`).
  *   - `migrate --from-local [--include-env] [--include-oauth] [--dry-run]` —
@@ -50,6 +50,7 @@ export interface AuthBrokerCommandArgs {
 		via?: string;
 		provider?: string;
 		dryRun?: boolean;
+		deviceAuth?: boolean;
 		/** `login`/`logout`: provider id. `import`: filesystem path. */
 		source?: string;
 		/** `import`: keep credentials whose JSON had `disabled: true`. */
@@ -80,6 +81,21 @@ const CALLBACK_PORTS: Record<string, number> = Object.fromEntries(
 		provider.callbackPort != null ? [[provider.id, provider.callbackPort] as [string, number]] : [],
 	),
 );
+
+const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+const OPENAI_CODEX_DEVICE_PROVIDER_ID = "openai-codex-device";
+const AUTH_BROKER_PROVIDER_ALIASES: Record<string, string> = {
+	codex: OPENAI_CODEX_PROVIDER_ID,
+};
+
+function resolveLoginProviderArg(providerArg: string, flags: AuthBrokerCommandArgs["flags"]): string {
+	const aliased = AUTH_BROKER_PROVIDER_ALIASES[providerArg] ?? providerArg;
+	if (flags.deviceAuth !== true) return aliased;
+	if (aliased === OPENAI_CODEX_PROVIDER_ID || aliased === OPENAI_CODEX_DEVICE_PROVIDER_ID) {
+		return OPENAI_CODEX_DEVICE_PROVIDER_ID;
+	}
+	throw new Error("--device-auth is only supported for Codex subscription login (openai-codex/codex)");
+}
 
 function getTokenFilePath(): string {
 	return path.join(getConfigRootDir(), "auth-broker.token");
@@ -180,6 +196,9 @@ async function runToken(flags: AuthBrokerCommandArgs["flags"]): Promise<void> {
 async function runLogin(flags: AuthBrokerCommandArgs["flags"]): Promise<void> {
 	const providers = getOAuthProviders();
 	let providerArg = flags.provider;
+	if (!providerArg && flags.deviceAuth === true) {
+		providerArg = OPENAI_CODEX_PROVIDER_ID;
+	}
 	if (!providerArg) {
 		if (flags.via) {
 			throw new Error(
@@ -188,6 +207,7 @@ async function runLogin(flags: AuthBrokerCommandArgs["flags"]): Promise<void> {
 		}
 		providerArg = await pickProviderInteractively(providers);
 	}
+	providerArg = resolveLoginProviderArg(providerArg, flags);
 	if (!providers.some(p => p.id === providerArg)) {
 		throw new Error(
 			`Unknown OAuth provider '${providerArg}'. Known: ${providers
@@ -326,19 +346,17 @@ async function pickProviderInteractively(providers: readonly OAuthProviderInfo[]
 
 async function runRemoteLogin(provider: string, via: string, dryRun: boolean): Promise<void> {
 	const port = CALLBACK_PORTS[provider];
-	if (port === undefined) {
-		throw new Error(
-			`No known OAuth callback port for '${provider}'. Use device-code flow on the broker host directly.`,
-		);
-	}
-	const sshArgs = [
-		"-L",
-		`${port}:127.0.0.1:${port}`,
-		"-o",
-		"ExitOnForwardFailure=yes",
-		via,
-		`${APP_NAME} auth-broker login ${provider}`,
-	];
+	const sshArgs =
+		port === undefined
+			? [via, `${APP_NAME} auth-broker login ${provider}`]
+			: [
+					"-L",
+					`${port}:127.0.0.1:${port}`,
+					"-o",
+					"ExitOnForwardFailure=yes",
+					via,
+					`${APP_NAME} auth-broker login ${provider}`,
+				];
 	if (dryRun) {
 		process.stdout.write(`ssh ${sshArgs.map(a => (a.includes(" ") ? `'${a}'` : a)).join(" ")}\n`);
 		return;

--- a/packages/coding-agent/src/commands/auth-broker.ts
+++ b/packages/coding-agent/src/commands/auth-broker.ts
@@ -34,6 +34,9 @@ export default class AuthBroker extends Command {
 		via: Flags.string({
 			description: "SSH user@host for remote login (login --via=user@host)",
 		}),
+		"device-auth": Flags.boolean({
+			description: "Use Codex device-code login (headless; equivalent to `codex login --device-auth`)",
+		}),
 		provider: Flags.string({
 			description: "Override provider id for `import` (e.g. when JSON `type` is unrecognized)",
 		}),
@@ -60,6 +63,8 @@ export default class AuthBroker extends Command {
 		`# List supported OAuth providers\n  ${APP_NAME} auth-broker list`,
 		`# Local login (run on the broker host)\n  ${APP_NAME} auth-broker login anthropic`,
 		`# Interactive provider selection\n  ${APP_NAME} auth-broker login`,
+		`# Headless Codex subscription login (device-code flow)\n  ${APP_NAME} auth-broker login --device-auth`,
+		`# Remote headless Codex subscription login over SSH\n  ${APP_NAME} auth-broker login --device-auth --via=user@broker`,
 		`# Remote login over SSH tunnel\n  ${APP_NAME} auth-broker login anthropic --via=user@broker`,
 		`# Log out of a provider (interactive without provider arg)\n  ${APP_NAME} auth-broker logout anthropic`,
 		`# Import a CLIProxyAPI auth dump\n  ${APP_NAME} auth-broker import ~/.cliproxy/auth`,
@@ -83,6 +88,7 @@ export default class AuthBroker extends Command {
 				bind: flags.bind,
 				regenerate: flags.regenerate,
 				via: flags.via,
+				deviceAuth: flags["device-auth"],
 				// `login`/`logout` reuse the legacy `provider` slot; `import` keeps `source` separate
 				// so `provider` flag (used as an override) is unambiguous.
 				provider: action === "import" ? flags.provider : (args.source ?? flags.provider),

--- a/packages/coding-agent/test/auth-broker-login-device.test.ts
+++ b/packages/coding-agent/test/auth-broker-login-device.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { runAuthBrokerCommand } from "@oh-my-pi/pi-coding-agent/cli/auth-broker-cli";
+
+const ORIGINAL_STDOUT_WRITE = process.stdout.write.bind(process.stdout);
+
+function captureStdout(): () => string {
+	let captured = "";
+	process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+		captured += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+		return true;
+	}) as typeof process.stdout.write;
+	return () => captured;
+}
+
+describe("auth-broker Codex device login", () => {
+	afterEach(() => {
+		process.stdout.write = ORIGINAL_STDOUT_WRITE;
+	});
+
+	test("maps --device-auth to the Codex device-code provider for remote dry runs", async () => {
+		const readStdout = captureStdout();
+
+		await runAuthBrokerCommand({
+			action: "login",
+			flags: { deviceAuth: true, via: "user@broker", dryRun: true },
+		});
+
+		const output = readStdout();
+		expect(output).toContain("ssh user@broker");
+		expect(output).toContain("auth-broker login openai-codex-device");
+		expect(output).not.toContain(" -L ");
+	});
+
+	test("accepts codex as the browser-login provider alias", async () => {
+		const readStdout = captureStdout();
+
+		await runAuthBrokerCommand({
+			action: "login",
+			flags: { provider: "codex", via: "user@broker", dryRun: true },
+		});
+
+		const output = readStdout();
+		expect(output).toContain("1455:127.0.0.1:1455");
+		expect(output).toContain("auth-broker login openai-codex");
+	});
+});

--- a/packages/coding-agent/test/modes/components/oauth-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/oauth-selector.test.ts
@@ -49,6 +49,29 @@ describe("OAuthSelectorComponent", () => {
 		expect(selected).toEqual([target.id]);
 	});
 
+	it("labels the Codex device-code login option", () => {
+		const selected: string[] = [];
+		const component = new OAuthSelectorComponent(
+			"login",
+			authStorage,
+			providerId => selected.push(providerId),
+			() => {},
+		);
+
+		for (const char of "openai-codex-device") {
+			component.handleInput(char);
+		}
+
+		const rendered = component
+			.render(80)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+		expect(rendered).toContain("Codex (device code)");
+
+		component.handleInput("\n");
+		expect(selected).toEqual(["openai-codex-device"]);
+	});
+
 	it("guides slash-command input back to the TUI after setup is skipped", () => {
 		const component = new OAuthSelectorComponent(
 			"login",


### PR DESCRIPTION
## What
- Add a `Codex (device code)` OAuth provider option to the `/login` selector.
- Run the official Codex headless device-code flow and store credentials under `openai-codex`.
- Keep `omh auth-broker login --device-auth` for headless / remote broker login without a callback tunnel.

## Verification
- `bun test packages/coding-agent/test/modes/components/oauth-selector.test.ts`
- `bun test packages/coding-agent/test/auth-broker-login-device.test.ts`
- `bun test packages/ai/test/provider-registry.test.ts`
- `bun test packages/ai/test/openai-codex.test.ts`
- `cd packages/ai && bun check`
- `cd packages/coding-agent && bun check`