### PR TITLE
Add humanize gen-idea workflow

### DIFF
--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -699,10 +699,15 @@ describe("OpenAI-family first-event timeouts", () => {
 		}).result();
 
 		expect(result.stopReason).toBe("error");
-		expect(result.errorMessage).toBe("OpenAI responses stream closed before a terminal response event was received");
+		expect(result.errorMessage).toContain(
+			"OpenAI responses stream closed before a terminal response event was received",
+		);
 		expect(result.content as unknown[]).toEqual([
 			{ type: "text", text: "Hello", textSignature: '{"v":1,"id":"msg_incomplete"}' },
 		]);
+		expect(result.errorMessage).toContain(
+			"request-context: provider=openai api=openai-responses model=gpt-5-mini url=https://api.openai.com/v1/responses",
+		);
 	});
 
 	it("errors when Azure OpenAI responses stream closes without a terminal response event", async () => {
@@ -741,12 +746,15 @@ describe("OpenAI-family first-event timeouts", () => {
 		}).result();
 
 		expect(result.stopReason).toBe("error");
-		expect(result.errorMessage).toBe(
+		expect(result.errorMessage).toContain(
 			"Azure OpenAI responses stream closed before a terminal response event was received",
 		);
 		expect(result.content as unknown[]).toEqual([
 			{ type: "text", text: "Hello azure", textSignature: '{"v":1,"id":"msg_incomplete_azure"}' },
 		]);
+		expect(result.errorMessage).toContain(
+			"request-context: provider=azure api=azure-openai-responses model=gpt-5-mini url=https://example.openai.azure.com/openai/v1/responses?api-version=v1",
+		);
 	});
 
 	it("handles response.incomplete as a valid terminal event (not premature closure)", async () => {

--- a/packages/ai/test/openai-responses-transport-error-context.test.ts
+++ b/packages/ai/test/openai-responses-transport-error-context.test.ts
@@ -37,7 +37,7 @@ describe("openai-responses transport error context", () => {
 		}).result();
 
 		expect(result.stopReason).toBe("error");
-		expect(result.errorMessage).toContain("Connection error.");
+		expect(result.errorMessage).toContain("JSON Parse error: Unexpected EOF");
 		expect(result.errorMessage).toContain("provider=rust-cat");
 		expect(result.errorMessage).toContain("api=openai-responses");
 		expect(result.errorMessage).toContain("model=gpt-5.5");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed completed workflow attempts surfacing only `workflow completed`, so final node summaries now remind users where generated artifacts were saved.
 - Fixed the experimental performance-optimization-search flow treating a committed positive selection with a clean worktree as a no-win outcome during finalize/archive.
 - Fixed the experimental research-reproduction flow assuming comparison agent summaries automatically materialized `/comparison` before review prompts.
 - Fixed headless workflow starts returning success when scheduler-level prompt binding failures failed the run, and now persist those failures into workflow observability.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed workflow runner stop handling preserving explicit node abort signals and waiting for node abort before checkpointing graceful stops.
+- Fixed successful subagent yields parking history-only sessions without aborting the completed session.
 - Fixed completed workflow attempts surfacing only `workflow completed`, so final node summaries now remind users where generated artifacts were saved.
 - Fixed the experimental performance-optimization-search flow treating a committed positive selection with a clean worktree as a no-win outcome during finalize/archive.
 - Fixed the experimental research-reproduction flow assuming comparison agent summaries automatically materialized `/comparison` before review prompts.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the experimental humanize-gen-idea workflow for generating repo-grounded Humanize idea drafts from inline or file input.
+
 ### Fixed
 
 - Fixed the experimental performance-optimization-search flow treating a committed positive selection with a clean worktree as a no-win outcome during finalize/archive.

--- a/packages/coding-agent/examples/workflow/experimental/README.md
+++ b/packages/coding-agent/examples/workflow/experimental/README.md
@@ -14,6 +14,7 @@ Current promoted built-ins: none.
 | --- | --- | --- |
 | `agent-build-review-loop` | Real build/review loop evidence on HTTPX plus recent Vite semantic canaries. | 100h cumulative clean evidence across diverse contexts. |
 | `humanize-rlcr` | Real RLCR-style implementation/review evidence and recent Axum semantic canaries. | Longer clean current-commit evidence and broader contexts. |
+| `humanize-gen-idea` | Workflow-native port of Humanize `/humanize:gen-idea`; initial canary only. | Fresh long-running evidence across diverse repositories and generated-draft audits. |
 | `kda-humanize` | Nested subflow composition and KDA-style candidate validation evidence. | Fresh clean long-running runs after recent KDA flow-control repairs. |
 | `parallel-implementation-review` | Real parallel implementation/review evidence and repaired durable final archive contract. | Fresh clean long-running runs after finalizer repair. |
 | `bug-triage-repro-fix` | Seeded candidate for reproduce-first bug repair. | First fresh canary-grade success sample or recorded-and-repaired defect. |

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea.omhflow
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea.omhflow
@@ -1,0 +1,122 @@
+---
+name: humanize-gen-idea
+version: 1
+schema: omhflow/v1
+models:
+  roles:
+    lead: gpt-5.5
+  defaults:
+    agent: lead
+  unavailable: fallback-to-parent
+checkpoint:
+  stopDeadlineMs: 30000
+changePolicy:
+  agentsCanPropose: true
+  humansCanApprove: true
+---
+# Humanize Gen Idea
+
+Generate a repo-grounded Humanize idea draft from loose input. This is the
+workflow-native counterpart to the Humanize Claude plugin `/humanize:gen-idea`.
+
+Start interactively with `/workflow start experimental::humanize-gen-idea`. The
+workflow first reads `.humanize/gen-idea.args`; if it is missing, a human input
+node asks for the same native gen-idea argument string in the TUI.
+
+```yaml workflow
+stateSchema:
+  version: 1
+  shape:
+    ideaArgs: object
+    /ideaArgs/status: string
+    idea: object
+    result: object
+resources:
+  - path: prompts/collect-input.md
+    kind: prompt
+  - path: prompts/generate-draft.md
+    kind: prompt
+  - path: scripts/load-idea-args.js
+    kind: script
+  - path: scripts/record-human-idea-args.js
+    kind: script
+  - path: scripts/validate-idea-io.js
+    kind: script
+  - path: scripts/verify-draft.js
+    kind: script
+  - path: templates/gen-idea-template.md
+    kind: data
+capabilities:
+  tools:
+    - ask
+    - eval
+    - task
+  agents:
+    - task
+nodes:
+  - id: loadIdeaArgs
+    type: script
+    script:
+      language: js
+      file: scripts/load-idea-args.js
+    writes:
+      - /ideaArgs
+  - id: collectIdeaInput
+    type: human
+    prompt:
+      file: prompts/collect-input.md
+  - id: recordHumanIdeaArgs
+    type: script
+    script:
+      language: js
+      file: scripts/record-human-idea-args.js
+    writes:
+      - /ideaArgs
+  - id: validateIdeaInput
+    type: script
+    script:
+      language: js
+      file: scripts/validate-idea-io.js
+    reads:
+      - /ideaArgs
+    writes:
+      - /idea
+  - id: generateDraft
+    type: agent
+    agent: task
+    model:
+      role: lead
+    workspaceAccess: write
+    reads:
+      - /idea
+    prompt:
+      template:
+        file: prompts/generate-draft.md
+        bindings:
+          idea:
+            state: /idea
+  - id: verifyDraft
+    type: script
+    script:
+      language: js
+      file: scripts/verify-draft.js
+    reads:
+      - /idea
+    writes:
+      - /result
+edges:
+  - from: loadIdeaArgs
+    to: validateIdeaInput
+    when: state.ideaArgs.status == "loaded"
+  - from: loadIdeaArgs
+    to: collectIdeaInput
+    when: state.ideaArgs.status != "loaded"
+  - from: collectIdeaInput
+    to: recordHumanIdeaArgs
+  - from: recordHumanIdeaArgs
+    to: validateIdeaInput
+  - from: validateIdeaInput
+    to: generateDraft
+  - from: generateDraft
+    to: verifyDraft
+```

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/prompts/collect-input.md
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/prompts/collect-input.md
@@ -1,0 +1,28 @@
+# Humanize Gen Idea Input
+
+Enter native `/humanize:gen-idea` arguments as custom input:
+
+```text
+"<idea-text-or-path>" [--n <int>] [--output <path>]
+```
+
+Rules:
+- First positional = inline idea text or existing `.md` path.
+- Quote multi-word inline ideas.
+- `--n` range = 2..10; default = 6.
+- `--output` default = `.humanize/ideas/<slug>-<timestamp>.md`.
+
+Examples:
+
+```text
+"add undo/redo to the editor" --n 4
+```
+
+```text
+notes/rough-idea.md --output docs/idea-draft.md
+```
+
+Important TUI detail:
+- Select `Other` / custom input and type the argument string.
+- Do not choose `Decision: proceed`; that is a generic workflow gate option, not an argument.
+- Prefer `.humanize/gen-idea.args` for headless runs or if your TUI surface does not expose custom input clearly.

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/prompts/generate-draft.md
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/prompts/generate-draft.md
@@ -10,7 +10,7 @@ Validated input:
 
 You MUST NOT implement features, modify source code, or create commits. The only permitted project write is the final draft file at `idea.outputFile`. Do not write workflow-output artifacts.
 
-This workflow transforms a loose idea into a repo-grounded draft suitable as input to Humanize gen-plan. It applies directed-diversity exploration: pick `idea.n` orthogonal directions, launch `idea.n` read-only exploration subagents in one Task-tool call, then synthesize one primary direction plus alternatives. Every direction MUST carry objective evidence from this repo or the sentinel `exploratory, no concrete precedent`.
+This workflow transforms a loose idea into a repo-grounded draft suitable as the task contract for experimental `humanize-rlcr`: review/copy the saved draft to `task.md` or `TASK.md`, then start `/workflow start experimental::humanize-rlcr`. It applies directed-diversity exploration: pick `idea.n` orthogonal directions, launch `idea.n` read-only exploration subagents in one Task-tool call, then synthesize one primary direction plus alternatives. Every direction MUST carry objective evidence from this repo or the sentinel `exploratory, no concrete precedent`.
 
 ## Inputs
 
@@ -110,4 +110,3 @@ Write `idea.outputFile` exactly once. Then report:
 - Primary direction name.
 - Requested `idea.n` and actual surviving direction count.
 - Validation warnings, if any.
-- Next step: `/humanize:gen-plan --input <OUTPUT_FILE> --output <plan-path>`.

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/prompts/generate-draft.md
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/prompts/generate-draft.md
@@ -1,0 +1,113 @@
+# Generate Humanize Idea Draft
+
+Validated input:
+
+```json
+{{jsonStringify idea}}
+```
+
+## Hard Constraint: Draft-Only Output
+
+You MUST NOT implement features, modify source code, or create commits. The only permitted project write is the final draft file at `idea.outputFile`. Do not write workflow-output artifacts.
+
+This workflow transforms a loose idea into a repo-grounded draft suitable as input to Humanize gen-plan. It applies directed-diversity exploration: pick `idea.n` orthogonal directions, launch `idea.n` read-only exploration subagents in one Task-tool call, then synthesize one primary direction plus alternatives. Every direction MUST carry objective evidence from this repo or the sentinel `exploratory, no concrete precedent`.
+
+## Inputs
+
+- Original idea body: `idea.ideaBody` for inline input, or `idea.ideaBodyFile` for file input.
+- Output draft file: `idea.outputFile`.
+- Draft template file: `idea.templateFile`.
+- Direction count: `idea.n`.
+- Validation warnings: `idea.warnings`.
+
+Before doing anything else, load the original idea body: use `idea.ideaBody` when present, otherwise read `idea.ideaBodyFile`. Preserve it byte-identically when populating `<ORIGINAL_IDEA>`.
+
+## Phase 1: Context
+
+Read, when present:
+- `README.md` at the project root.
+- `CLAUDE.md` at the project root.
+- `.claude/CLAUDE.md`.
+- One-level top-level project listing.
+
+Use this context only to ground directions. Do not inspect unrelated deep trees unless a direction needs evidence.
+
+## Phase 2: Direction Generation
+
+Generate exactly `idea.n` orthogonal directions.
+
+Each direction has:
+- `name`: 2-5 word short label.
+- `rationale`: one sentence explaining why this angle is distinct.
+
+Hard constraint: orthogonality. Near-duplicates defeat the workflow.
+- Duplicate angles? Replace one.
+- "Just do X better"? Replace it.
+- Restatement of the original idea? Replace it.
+
+Retry once if fewer than `idea.n` directions are produced. If the retry still returns fewer than requested but at least 2, proceed with the reduced count and mention the warning in your final response. If fewer than 2 directions remain, stop without writing `idea.outputFile` and report `direction generation degraded; retry.`
+
+## Phase 3: Parallel Exploration
+
+Dispatch all directions in a single Task-tool call: one read-only Explore subagent per direction.
+
+Each subagent prompt MUST include:
+1. The verbatim original idea body loaded from `idea.ideaBody` or `idea.ideaBodyFile`.
+2. The assigned direction name + rationale.
+3. This exact instruction block:
+
+> Explore this direction within the current repo. Gather OBJECTIVE EVIDENCE:
+> - Specific repo paths with existing patterns worth extending.
+> - Prior art or precedent in the codebase or adjacent tooling.
+> - Measurable considerations (approximate complexity, LOC surface, performance implications) where discoverable from reading the code.
+>
+> Read-only. Do not write any files. Do not run tests, linters, formatters, or project-wide commands.
+>
+> If no concrete evidence exists for this direction, report the literal string `exploratory, no concrete precedent` once in OBJECTIVE_EVIDENCE and stop exploring further. Fabrication of references is forbidden.
+>
+> Return a structured proposal with exactly these fields:
+> - `APPROACH_SUMMARY`: concrete design description (what to build, core mechanism, affected components).
+> - `OBJECTIVE_EVIDENCE`: bullet list of repo paths, prior art, or the `exploratory, no concrete precedent` sentinel.
+> - `KNOWN_RISKS`: short bullet list.
+> - `CONFIDENCE`: one of `high`, `medium`, `low`.
+
+Drop degraded proposals with missing fields. If fewer than 2 proposals survive, stop without writing `idea.outputFile` and report `exploration phase degraded; retry.`
+
+## Phase 4: Synthesis and Write
+
+Choose the primary proposal by:
+1. Evidence density.
+2. Fit with existing repo patterns.
+3. Smaller implementation surface when quality is comparable.
+4. Confidence as tie-breaker: `high` > `medium` > `low`.
+
+Generate a 4-10 word Title Case title that captures the primary direction, not the original phrasing verbatim.
+
+Read `idea.templateFile`. Replace placeholders:
+- `<TITLE>` — inferred title.
+- `<ORIGINAL_IDEA>` — byte-identical original idea body loaded from `idea.ideaBody` or `idea.ideaBodyFile`.
+- `<PRIMARY_NAME>` — primary direction name.
+- `<PRIMARY_RATIONALE>` — primary direction rationale.
+- `<PRIMARY_APPROACH_SUMMARY>` — primary proposal `APPROACH_SUMMARY`.
+- `<PRIMARY_OBJECTIVE_EVIDENCE>` — primary `OBJECTIVE_EVIDENCE` as bullets; sentinel renders as `- exploratory, no concrete precedent`.
+- `<PRIMARY_KNOWN_RISKS>` — primary `KNOWN_RISKS` as bullets.
+- `<ALTERNATIVES>` — one section per non-primary survivor:
+
+```markdown
+### Alt-<i>: <name>
+- Gist: <one-paragraph summary derived from APPROACH_SUMMARY>
+- Objective Evidence:
+  - <bullet from OBJECTIVE_EVIDENCE>
+- Why not primary: <one sentence stating the tradeoff vs PRIMARY>
+```
+
+Separate alternatives with one blank line. Renumber alternatives sequentially without gaps.
+
+- `<SYNTHESIS_NOTES>` — one paragraph describing which alternative elements could fold into the primary if the user chose a different direction.
+
+Write `idea.outputFile` exactly once. Then report:
+- Path written.
+- Primary direction name.
+- Requested `idea.n` and actual surviving direction count.
+- Validation warnings, if any.
+- Next step: `/humanize:gen-plan --input <OUTPUT_FILE> --output <plan-path>`.

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/load-idea-args.js
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/load-idea-args.js
@@ -1,0 +1,49 @@
+const argsPath = ".humanize/gen-idea.args";
+const raw = await readOptionalText(argsPath);
+const argsText = raw?.trim();
+
+if (argsText) {
+	return {
+		summary: `loaded gen-idea arguments from ${argsPath}`,
+		statePatch: [
+			{
+				op: "set",
+				path: "/ideaArgs",
+				value: {
+					status: "loaded",
+					source: "file",
+					file: argsPath,
+					argsText,
+				},
+			},
+		],
+	};
+}
+
+return {
+	summary: `no ${argsPath} file found; requesting interactive gen-idea arguments`,
+	statePatch: [
+		{
+			op: "set",
+			path: "/ideaArgs",
+			value: {
+				status: "missing",
+				source: raw === undefined ? "none" : "empty-file",
+				file: argsPath,
+			},
+		},
+	],
+};
+
+async function readOptionalText(filePath) {
+	try {
+		return await Bun.file(filePath).text();
+	} catch (error) {
+		if (isEnoent(error)) return undefined;
+		throw error;
+	}
+}
+
+function isEnoent(error) {
+	return error && typeof error === "object" && "code" in error && error.code === "ENOENT";
+}

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/record-human-idea-args.js
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/record-human-idea-args.js
@@ -1,0 +1,28 @@
+const humanActivation = [...workflowContext.completedActivations]
+	.reverse()
+	.find(activation => activation.nodeId === "collectIdeaInput");
+const output = humanActivation?.output && typeof humanActivation.output === "object" ? humanActivation.output : {};
+const data = output.data && typeof output.data === "object" ? output.data : {};
+const response = typeof data.response === "string" ? data.response : typeof output.summary === "string" ? output.summary : "";
+const argsText = response.trim();
+
+if (!argsText || /^Decision:\s*(?:proceed|stop|hold)\b/iu.test(argsText)) {
+	throw new Error(
+		'Missing gen-idea arguments. Restart the workflow and use the Ask dialog\'s `Other` / custom input field, or create `.humanize/gen-idea.args` with e.g. `"add undo/redo" --n 4`.',
+	);
+}
+
+return {
+	summary: "recorded interactive gen-idea arguments",
+	statePatch: [
+		{
+			op: "set",
+			path: "/ideaArgs",
+			value: {
+				status: "loaded",
+				source: "human",
+				argsText,
+			},
+		},
+	],
+};

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/validate-idea-io.js
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/validate-idea-io.js
@@ -1,0 +1,323 @@
+const argsState = workflowContext.state?.ideaArgs;
+if (!argsState || typeof argsState !== "object") {
+	throw new Error("Missing or empty idea input");
+}
+const argsText = typeof argsState.argsText === "string" ? argsState.argsText.trim() : "";
+if (!argsText) {
+	throw new Error("Missing or empty idea input");
+}
+
+const tokens = parseCommandArgs(argsText);
+const parsed = parseGenIdeaArgs(tokens);
+const n = parseDirectionCount(parsed.n);
+const warnings = [];
+
+const input = await resolveIdeaInput(parsed.ideaInput, warnings);
+const projectRoot = await resolveProjectRoot();
+const output = await resolveOutputPath({
+	outputFile: parsed.outputFile,
+	projectRoot,
+	slug: input.slug,
+});
+const templateFile = resolveTemplateFile();
+await assertFileExists(templateFile, "Template file missing — plugin configuration error");
+
+const idea = {
+	inputMode: input.mode,
+	input: parsed.ideaInput,
+	source: typeof argsState.source === "string" ? argsState.source : "unknown",
+	n,
+	requestedN: n,
+	outputFile: output.outputFile,
+	slug: input.slug,
+	templateFile,
+	warnings,
+	rawArgs: argsText,
+};
+if (input.mode === "file") {
+	idea.ideaBodyFile = input.ideaBodyFile;
+} else {
+	idea.ideaBody = `${parsed.ideaInput}\n`;
+}
+
+return {
+	summary: `validated humanize gen-idea input; mode=${input.mode}; n=${n}; output=${output.outputFile}`,
+	data: {
+		inputMode: input.mode,
+		outputFile: output.outputFile,
+		slug: input.slug,
+		n,
+		warnings,
+	},
+	statePatch: [{ op: "set", path: "/idea", value: idea }],
+};
+
+function parseGenIdeaArgs(tokens) {
+	let ideaInput = "";
+	let n = "6";
+	let outputFile = "";
+	for (let index = 0; index < tokens.length; index += 1) {
+		const token = tokens[index];
+		if (token === "--n") {
+			const value = tokens[index + 1];
+			if (!value || value.startsWith("--")) throw invalidArguments("ERROR: --n requires a value");
+			n = value;
+			index += 1;
+			continue;
+		}
+		if (token === "--output") {
+			const value = tokens[index + 1];
+			if (!value || value.startsWith("--")) throw invalidArguments("ERROR: --output requires a value");
+			outputFile = value;
+			index += 1;
+			continue;
+		}
+		if (token === "-h" || token === "--help") throw invalidArguments();
+		if (token.startsWith("--")) throw invalidArguments(`ERROR: Unknown option: ${token}`);
+		if (!ideaInput) {
+			ideaInput = token;
+			continue;
+		}
+		throw invalidArguments(`ERROR: Unexpected positional argument: ${token}`);
+	}
+	if (!ideaInput) throw new Error("Missing or empty idea input");
+	return { ideaInput, n, outputFile };
+}
+
+function parseDirectionCount(value) {
+	if (!/^[0-9]+$/u.test(value)) {
+		throw invalidArguments(`--n must be a non-negative integer; got: ${value}`);
+	}
+	const n = Number(value);
+	if (n < 2 || n > 10) {
+		throw invalidArguments(`--n must be between 2 and 10 inclusive; got: ${value}`);
+	}
+	return n;
+}
+
+async function resolveIdeaInput(ideaInput, warnings) {
+	const file = Bun.file(ideaInput);
+	if (await file.exists()) {
+		if (!ideaInput.endsWith(".md")) {
+			throw new Error("Input looks like a file path but is missing, not readable, or not `.md`");
+		}
+		let body;
+		try {
+			body = await file.arrayBuffer();
+		} catch {
+			throw new Error("Input looks like a file path but is missing, not readable, or not `.md`");
+		}
+		if (body.byteLength === 0) throw new Error("Missing or empty idea input");
+		return {
+			mode: "file",
+			ideaBodyFile: normalizePath(ideaInput),
+			slug: basename(ideaInput, ".md"),
+		};
+	}
+	if (looksLikePath(ideaInput)) {
+		throw new Error("Input looks like a file path but is missing, not readable, or not `.md`");
+	}
+	if (ideaInput.length < 10) warnings.push(`WARNING: short idea (${ideaInput.length} chars); proceeding`);
+	return {
+		mode: "inline",
+		slug: slugFromInlineIdea(ideaInput),
+	};
+}
+
+function looksLikePath(value) {
+	return !/\s/u.test(value) && (value.endsWith(".md") || value.includes("/") || value.includes("\\"));
+}
+
+async function resolveOutputPath({ outputFile, projectRoot, slug }) {
+	const isDefault = !outputFile;
+	const resolvedOutput = normalizePath(
+		isDefault ? joinPath(projectRoot, ".humanize", "ideas", `${slug}-${timestamp()}.md`) : outputFile,
+	);
+	const outputDir = dirname(resolvedOutput);
+	if (isDefault) {
+		if (!(await hasWritePermission(outputDir))) throw new Error("No write permission to output directory");
+	} else {
+		if (!(await isDirectory(outputDir))) {
+			throw new Error("Output directory does not exist — please create it or choose a different path");
+		}
+		if (!(await hasWritePermission(outputDir))) throw new Error("No write permission to output directory");
+	}
+	if (await Bun.file(resolvedOutput).exists()) {
+		throw new Error("Output file already exists — choose a different path");
+	}
+	return { outputFile: resolvedOutput };
+}
+
+function resolveTemplateFile() {
+	const resourceRoot = workflowContext.resources?.root;
+	if (typeof resourceRoot !== "string" || !resourceRoot) {
+		throw new Error("Template file missing — plugin configuration error");
+	}
+	return joinPath(resourceRoot, "templates", "gen-idea-template.md");
+}
+
+async function resolveProjectRoot() {
+	try {
+		const proc = Bun.spawn(["git", "rev-parse", "--show-toplevel"], {
+			cwd: process.cwd(),
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		if (exitCode === 0 && stdout.trim()) return stdout.trim();
+	} catch {
+		// Fall back to the workflow cwd below.
+	}
+	return process.cwd();
+}
+
+async function assertFileExists(filePath, message) {
+	const stat = await statOptional(filePath);
+	if (!stat?.isFile()) throw new Error(message);
+}
+
+async function isDirectory(filePath) {
+	const stat = await statOptional(filePath);
+	return stat?.isDirectory() === true;
+}
+
+async function hasWritePermission(filePath) {
+	try {
+		const testPath = joinPath(filePath, `.omh-write-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		await Bun.write(testPath, "");
+		try {
+			await Bun.file(testPath).delete();
+		} catch {
+			// A failed cleanup should not mask successful write permission.
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function statOptional(filePath) {
+	try {
+		return await Bun.file(filePath).stat();
+	} catch {
+		return undefined;
+	}
+}
+
+function timestamp(date = new Date()) {
+	const year = date.getFullYear();
+	const month = pad(date.getMonth() + 1);
+	const day = pad(date.getDate());
+	const hour = pad(date.getHours());
+	const minute = pad(date.getMinutes());
+	const second = pad(date.getSeconds());
+	return `${year}${month}${day}-${hour}${minute}${second}`;
+}
+
+function pad(value) {
+	return String(value).padStart(2, "0");
+}
+
+function slugFromInlineIdea(ideaInput) {
+	const firstFortyBytes = new TextDecoder().decode(new TextEncoder().encode(ideaInput).slice(0, 40));
+	const slug = firstFortyBytes
+		.toLowerCase()
+		.replace(/[^a-z0-9-]+/gu, "-")
+		.replace(/-+/gu, "-")
+		.replace(/^-+|-+$/gu, "");
+	return slug || "idea";
+}
+
+function joinPath(...segments) {
+	return normalizeAbsolutePath(segments.filter(Boolean).join("/"));
+}
+
+function normalizePath(value) {
+	if (value.startsWith("/")) return normalizeAbsolutePath(value);
+	return normalizeAbsolutePath(`${process.cwd()}/${value}`);
+}
+
+function normalizeAbsolutePath(value) {
+	const parts = [];
+	for (const part of value.replace(/\\/gu, "/").split("/")) {
+		if (!part || part === ".") continue;
+		if (part === "..") {
+			parts.pop();
+			continue;
+		}
+		parts.push(part);
+	}
+	return `/${parts.join("/")}`;
+}
+
+function dirname(filePath) {
+	const normalized = normalizeAbsolutePath(filePath);
+	const index = normalized.lastIndexOf("/");
+	if (index <= 0) return "/";
+	return normalized.slice(0, index);
+}
+
+function basename(filePath, suffix = "") {
+	const normalized = filePath.replace(/\\/gu, "/").replace(/\/+$/u, "");
+	const base = normalized.slice(normalized.lastIndexOf("/") + 1);
+	return suffix && base.endsWith(suffix) ? base.slice(0, -suffix.length) : base;
+}
+
+function parseCommandArgs(source) {
+	const tokens = [];
+	let token = "";
+	let quote = "";
+	let escaping = false;
+	for (const char of source) {
+		if (escaping) {
+			token += char;
+			escaping = false;
+			continue;
+		}
+		if (char === "\\") {
+			escaping = true;
+			continue;
+		}
+		if (quote) {
+			if (char === quote) {
+				quote = "";
+				continue;
+			}
+			token += char;
+			continue;
+		}
+		if (char === "'" || char === '"') {
+			quote = char;
+			continue;
+		}
+		if (/\s/u.test(char)) {
+			if (token) {
+				tokens.push(token);
+				token = "";
+			}
+			continue;
+		}
+		token += char;
+	}
+	if (escaping) token += "\\";
+	if (quote) throw invalidArguments("ERROR: Unterminated quoted argument");
+	if (token) tokens.push(token);
+	return tokens;
+}
+
+function invalidArguments(message) {
+	return new Error([message, usageText()].filter(Boolean).join("\n"));
+}
+
+function usageText() {
+	return [
+		"Invalid arguments",
+		"Usage: <idea-text-or-path> [--n <int>] [--output <path>]",
+		"",
+		"Arguments:",
+		"  <idea-text-or-path>  Inline idea text OR path to an existing .md file (required)",
+		"  --n                  Number of directions (default: 6; range: 2-10)",
+		"  --output             Output draft path (default: .humanize/ideas/<slug>-<timestamp>.md)",
+		"  -h, --help           Show this help message",
+	].join("\n");
+}

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/verify-draft.js
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/verify-draft.js
@@ -33,15 +33,16 @@ if (unresolved) {
 	throw new Error(`draft still contains unresolved placeholder ${unresolved[0]}`);
 }
 
+const nextStep = `/humanize:gen-plan --input ${outputFile} --output <plan-path>`;
 const result = {
 	status: "written",
 	outputFile,
 	bytes: new TextEncoder().encode(draft).byteLength,
-	nextStep: `/humanize:gen-plan --input ${outputFile} --output <plan-path>`,
+	nextStep,
 };
 
 return {
-	summary: `verified generated idea draft at ${outputFile}`,
+	summary: `Idea draft saved to ${outputFile}. Next: ${nextStep}`,
 	data: result,
 	statePatch: [{ op: "set", path: "/result", value: result }],
 };

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/verify-draft.js
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/verify-draft.js
@@ -1,0 +1,60 @@
+const idea = workflowContext.state?.idea;
+if (!idea || typeof idea !== "object") {
+	throw new Error("humanize-gen-idea requires /idea before verifyDraft");
+}
+const outputFile = requiredString(idea.outputFile, "idea.outputFile");
+const expectedIdea = await originalIdeaBody(idea);
+let draft;
+try {
+	draft = await Bun.file(outputFile).text();
+} catch (error) {
+	throw new Error(`draft file was not generated: ${outputFile}`);
+}
+if (!draft.trim()) {
+	throw new Error(`draft file is empty: ${outputFile}`);
+}
+const requiredHeadings = [
+	"## Original Idea",
+	"## Primary Direction:",
+	"### Approach Summary",
+	"### Objective Evidence",
+	"### Known Risks",
+	"## Alternative Directions Considered",
+	"## Synthesis Notes",
+];
+for (const heading of requiredHeadings) {
+	if (!draft.includes(heading)) throw new Error(`draft missing required section: ${heading}`);
+}
+if (!draft.includes(expectedIdea.trim())) {
+	throw new Error("draft does not include the original idea body");
+}
+const unresolved = /<(?:TITLE|ORIGINAL_IDEA|PRIMARY_NAME|PRIMARY_RATIONALE|PRIMARY_APPROACH_SUMMARY|PRIMARY_OBJECTIVE_EVIDENCE|PRIMARY_KNOWN_RISKS|ALTERNATIVES|SYNTHESIS_NOTES)>/u.exec(draft);
+if (unresolved) {
+	throw new Error(`draft still contains unresolved placeholder ${unresolved[0]}`);
+}
+
+const result = {
+	status: "written",
+	outputFile,
+	bytes: new TextEncoder().encode(draft).byteLength,
+	nextStep: `/humanize:gen-plan --input ${outputFile} --output <plan-path>`,
+};
+
+return {
+	summary: `verified generated idea draft at ${outputFile}`,
+	data: result,
+	statePatch: [{ op: "set", path: "/result", value: result }],
+};
+
+function requiredString(value, label) {
+	if (typeof value === "string" && value.length > 0) return value;
+	throw new Error(`humanize-gen-idea requires ${label}`);
+}
+
+async function originalIdeaBody(idea) {
+	if (typeof idea.ideaBody === "string" && idea.ideaBody.length > 0) return idea.ideaBody;
+	if (typeof idea.ideaBodyFile === "string" && idea.ideaBodyFile.length > 0) {
+		return await Bun.file(idea.ideaBodyFile).text();
+	}
+	throw new Error("humanize-gen-idea requires idea.ideaBody or idea.ideaBodyFile");
+}

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/verify-draft.js
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/verify-draft.js
@@ -33,16 +33,14 @@ if (unresolved) {
 	throw new Error(`draft still contains unresolved placeholder ${unresolved[0]}`);
 }
 
-const nextStep = `/humanize:gen-plan --input ${outputFile} --output <plan-path>`;
 const result = {
 	status: "written",
 	outputFile,
 	bytes: new TextEncoder().encode(draft).byteLength,
-	nextStep,
 };
 
 return {
-	summary: `Idea draft saved to ${outputFile}. Next: ${nextStep}`,
+	summary: `Idea draft saved to ${outputFile}.`,
 	data: result,
 	statePatch: [{ op: "set", path: "/result", value: result }],
 };

--- a/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/templates/gen-idea-template.md
+++ b/packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/templates/gen-idea-template.md
@@ -1,0 +1,31 @@
+# <TITLE>
+
+## Original Idea
+
+<ORIGINAL_IDEA>
+
+## Primary Direction: <PRIMARY_NAME>
+
+### Rationale
+
+<PRIMARY_RATIONALE>
+
+### Approach Summary
+
+<PRIMARY_APPROACH_SUMMARY>
+
+### Objective Evidence
+
+<PRIMARY_OBJECTIVE_EVIDENCE>
+
+### Known Risks
+
+<PRIMARY_KNOWN_RISKS>
+
+## Alternative Directions Considered
+
+<ALTERNATIVES>
+
+## Synthesis Notes
+
+<SYNTHESIS_NOTES>

--- a/packages/coding-agent/src/cli/__tests__/workflow-cli.test.ts
+++ b/packages/coding-agent/src/cli/__tests__/workflow-cli.test.ts
@@ -219,10 +219,11 @@ describe("workflow CLI", () => {
 		});
 
 		const result = JSON.parse(output.join("").trim()) as {
-			run: { status: string; completed: number; failed: number };
+			run: { status: string; completed: number; failed: number; summary?: string };
 			runs: { stateKeys: string[] }[];
 		};
 		expect(result.run).toMatchObject({ status: "completed", completed: 1, failed: 0 });
+		expect(result.run.summary).toBe("resource observed");
 		expect(result.runs[0]?.stateKeys).toEqual(["message"]);
 	});
 

--- a/packages/coding-agent/src/cli/workflow-cli.ts
+++ b/packages/coding-agent/src/cli/workflow-cli.ts
@@ -313,6 +313,7 @@ async function handleStart(command: WorkflowCommandArgs, runtime: WorkflowComman
 				failed: result.scheduler.activations.filter(activation => activation.status === "failed").length,
 				frontier: result.scheduler.frontierNodeIds,
 				maxRuntimeMs: command.flags.maxRuntimeMs ?? DEFAULT_WORKFLOW_MAX_RUNTIME_MS,
+				summary: lifecycleAttempt?.summary,
 			},
 			failedActivations:
 				failedActivations.length > 0
@@ -364,6 +365,9 @@ async function handleStart(command: WorkflowCommandArgs, runtime: WorkflowComman
 	writeLine(`Workflow run: ${runId}`);
 	writeLine(`Flow: ${flowLabel(spec)}`);
 	writeLine(`Status: ${status}`);
+	if (lifecycleAttempt?.summary && lifecycleAttempt.summary !== "workflow completed") {
+		writeLine(`Summary: ${lifecycleAttempt.summary}`);
+	}
 	writeLine(
 		`Activations: ${result.scheduler.activations.length} total, ${result.scheduler.activations.filter(activation => activation.status === "completed").length} completed, ${result.scheduler.activations.filter(activation => activation.status === "failed").length} failed`,
 	);

--- a/packages/coding-agent/src/modes/components/workflow-graph.test.ts
+++ b/packages/coding-agent/src/modes/components/workflow-graph.test.ts
@@ -309,8 +309,7 @@ function completedConditionalBranchViewFixture(): WorkflowGraphView {
 			id: "attempt-1",
 			status: "completed",
 			runtimeBindingId: "binding-1",
-			summary:
-				"Idea draft saved to /tmp/idea.md. Next: /humanize:gen-plan --input /tmp/idea.md --output <plan-path>",
+			summary: "Idea draft saved to /tmp/idea.md.",
 		},
 		changes: { approved: 0, proposed: 0, rejected: 0 },
 		topology: {

--- a/packages/coding-agent/src/modes/components/workflow-graph.test.ts
+++ b/packages/coding-agent/src/modes/components/workflow-graph.test.ts
@@ -116,6 +116,17 @@ describe("WorkflowGraphComponent display modes", () => {
 		expect(text).not.toContain("7/8 done");
 	});
 
+	it("keeps completed workflow summaries visible in collapsed mode", () => {
+		const text = new WorkflowGraphComponent(completedConditionalBranchViewFixture(), {
+			displayModeProvider: () => "collapsed",
+		})
+			.render(140)
+			.map(stripAnsi)
+			.join("\n");
+
+		expect(text).toContain("Idea draft saved to /tmp/idea.md");
+	});
+
 	it("switches selected workflow nodes and activation summaries from keyboard input", () => {
 		const component = new WorkflowGraphComponent(workflowGraphNavigationViewFixture(), {
 			displayModeProvider: () => "full",
@@ -298,6 +309,8 @@ function completedConditionalBranchViewFixture(): WorkflowGraphView {
 			id: "attempt-1",
 			status: "completed",
 			runtimeBindingId: "binding-1",
+			summary:
+				"Idea draft saved to /tmp/idea.md. Next: /humanize:gen-plan --input /tmp/idea.md --output <plan-path>",
 		},
 		changes: { approved: 0, proposed: 0, rejected: 0 },
 		topology: {

--- a/packages/coding-agent/src/modes/components/workflow-graph.ts
+++ b/packages/coding-agent/src/modes/components/workflow-graph.ts
@@ -998,12 +998,13 @@ function renderWorkflowGraphCollapsedRows(view: WorkflowGraphView, width: number
 	const summaryParts = [
 		`Workflow ${attempt}`,
 		workflowGraphProgressSummary(view),
+		workflowGraphCompletionSummary(view),
 		view.focus === undefined ? undefined : `focus ${view.focus.nodeId}`,
 	].filter((part): part is string => part !== undefined && part.length > 0);
 	const guideParts = ["/workflow help", "/workflow help agents", "/workflow dashboard show"];
 	const primaryAction = workflowGraphCollapsedPrimaryAction(view);
 	if (width >= 160) {
-		const parts = [...summaryParts.slice(0, 2), ...guideParts, primaryAction, summaryParts[2]].filter(
+		const parts = [...summaryParts.slice(0, 2), ...guideParts, primaryAction, ...summaryParts.slice(2)].filter(
 			(part): part is string => part !== undefined && part.length > 0,
 		);
 		return [truncateToWidth(`${theme.fg(color, glyph)} ${parts.join(" · ")}`, width)];
@@ -1041,6 +1042,13 @@ function workflowGraphProgressSummary(view: WorkflowGraphView): string {
 		progress.skipped > 0 ? `${progress.skipped} skipped` : undefined,
 	].filter((part): part is string => part !== undefined);
 	return tail.join(" · ");
+}
+
+function workflowGraphCompletionSummary(view: WorkflowGraphView): string | undefined {
+	if (view.currentAttempt?.status !== "completed") return undefined;
+	const summary = view.currentAttempt.summary?.trim();
+	if (!summary || summary === "workflow completed") return undefined;
+	return formatWorkflowGraphHeadlineDetail(summary);
 }
 
 function workflowGraphCollapsedPrimaryAction(view: WorkflowGraphView): string | undefined {

--- a/packages/coding-agent/src/slash-commands/helpers/workflow.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/workflow.ts
@@ -168,6 +168,7 @@ interface ActiveWorkflowAttempt {
 	nodeAbortController: AbortController;
 	nodeAbortControllers: Map<string, AbortController>;
 	lifecycle: WorkflowRunnerLifecycleOptions;
+	announceCompletion: boolean;
 	finished: Promise<void>;
 }
 
@@ -486,6 +487,7 @@ async function handleStartCommand(rest: string, runtime: SlashCommandRuntime): P
 			nodeAbortController,
 			nodeAbortControllers,
 			lifecycle,
+			announceCompletion: runInBackground,
 			finished: runPromise.then(
 				() => undefined,
 				async error => {
@@ -1040,6 +1042,7 @@ async function handleRestartCommand(rest: string, runtime: SlashCommandRuntime):
 		nodeAbortController,
 		nodeAbortControllers,
 		lifecycle,
+		announceCompletion: parsed.background === true,
 		finished: runPromise.then(
 			() => undefined,
 			async error => {
@@ -1633,10 +1636,25 @@ function watchWorkflowAttemptCompletion(runtime: SlashCommandRuntime, active: Ac
 		try {
 			unregisterActiveWorkflowAttempt(runtime, active.attemptId);
 			await flushWorkflowLifecycle(runtime);
+			await outputWorkflowAttemptCompletionReminder(runtime, active);
 		} catch (error) {
 			await runtime.output(`Workflow attempt persistence failed: ${active.attemptId} - ${errorMessage(error)}`);
 		}
 	});
+}
+
+async function outputWorkflowAttemptCompletionReminder(
+	runtime: SlashCommandRuntime,
+	active: ActiveWorkflowAttempt,
+): Promise<void> {
+	if (!active.announceCompletion) return;
+	const family = reconstructWorkflowFamilies(runtime.sessionManager.getBranch()).find(
+		candidate => candidate.id === active.familyId,
+	);
+	const attempt = family?.attempts.find(candidate => candidate.id === active.attemptId);
+	const summary = attempt?.summary?.trim();
+	if (attempt?.status !== "completed" || !summary || summary === "workflow completed") return;
+	await runtime.output(`Workflow completed: ${active.attemptId} - ${summary}`);
 }
 
 function findActiveWorkflowAttempt(runtime: SlashCommandRuntime, attemptId: string): ActiveWorkflowAttempt | undefined {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1202,7 +1202,8 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 							args: eventArgs,
 							result: event.result,
 							isError: event.isError,
-						})
+						}) &&
+						!(event.toolName === "yield" && yieldCalled)
 					) {
 						requestAbort("terminate");
 					}
@@ -1830,11 +1831,11 @@ export async function finalizeSubagentLifecycle(args: {
 	}
 
 	if (args.isolated) {
-		// Isolated run: the worktree is merged + cleaned after the run, so
-		// the session is not resumable. Park the ref WITHOUT adopting — the
+		// Isolated successful run: the worktree is merged + cleaned after the run,
+		// so the session is not resumable. Park the ref WITHOUT adopting — the
 		// transcript stays reachable (history://), but ensureLive will throw.
-		// Status must flip to "parked" before dispose so the sdk dispose
-		// wrapper skips unregister.
+		// Status must flip to "parked" before dispose so the sdk dispose wrapper
+		// skips unregister.
 		registry.setRevivalPolicy(args.id, "history-only");
 		registry.setStatus(args.id, "parked");
 		await disposeSession();

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1516,7 +1516,39 @@ async function driveSessionToYield(
 	};
 	const awaitPromptOrYield = async <T>(promise: Promise<T>): Promise<T | undefined> => {
 		checkAbort();
-		if (monitor.yieldCalled()) return undefined;
+		let promptSettled = false;
+		const guardedPrompt = promise.then(
+			value => {
+				promptSettled = true;
+				return value;
+			},
+			error => {
+				promptSettled = true;
+				if (monitor.yieldCalled() || abortSignal.aborted) {
+					logger.debug("Subagent prompt settled after yield boundary", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+					return undefined;
+				}
+				throw error;
+			},
+		);
+		void guardedPrompt.catch(() => {});
+
+		const stopInFlightPromptAfterYield = async (): Promise<undefined> => {
+			// A terminal yield may be emitted synchronously just before prompt() resolves.
+			// Give that successful turn a chance to settle so completed sessions are not
+			// aborted, but stop genuinely in-flight prompts before resolving the subagent.
+			await Promise.resolve();
+			await Promise.resolve();
+			if (!promptSettled) {
+				await monitor.abortActiveSession();
+			}
+			return undefined;
+		};
+
+		if (monitor.yieldCalled()) return stopInFlightPromptAfterYield();
+
 		const { promise: abortPromise, reject } = Promise.withResolvers<never>();
 		const onAbort = () => {
 			try {
@@ -1526,18 +1558,12 @@ async function driveSessionToYield(
 			}
 		};
 		abortSignal.addEventListener("abort", onAbort, { once: true });
-		const guardedPrompt = promise.catch(error => {
-			if (monitor.yieldCalled() || abortSignal.aborted) {
-				logger.debug("Subagent prompt settled after yield boundary", {
-					error: error instanceof Error ? error.message : String(error),
-				});
-				return undefined;
-			}
-			throw error;
-		});
-		void guardedPrompt.catch(() => {});
 		try {
-			return await Promise.race([guardedPrompt, monitor.yieldObserved().then(() => undefined), abortPromise]);
+			return await Promise.race([
+				guardedPrompt,
+				monitor.yieldObserved().then(stopInFlightPromptAfterYield),
+				abortPromise,
+			]);
 		} finally {
 			abortSignal.removeEventListener("abort", onAbort);
 		}

--- a/packages/coding-agent/src/workflow/__tests__/example-flow-scripts.test.ts
+++ b/packages/coding-agent/src/workflow/__tests__/example-flow-scripts.test.ts
@@ -23,6 +23,7 @@ const RESEARCH_REPRODUCTION_SCRIPT_DIR = `${import.meta.dir}/../../../examples/w
 const RELEASE_HARDENING_SCRIPT_DIR = `${import.meta.dir}/../../../examples/workflow/experimental/release-hardening/release-hardening/scripts`;
 const BUG_TRIAGE_REPRO_FIX_SCRIPT_DIR = `${import.meta.dir}/../../../examples/workflow/experimental/bug-triage-repro-fix/bug-triage-repro-fix/scripts`;
 const HUMANIZE_GEN_IDEA_FLOW_PATH = `${import.meta.dir}/../../../examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea.omhflow`;
+const HUMANIZE_GEN_IDEA_SCRIPT_DIR = `${import.meta.dir}/../../../examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts`;
 
 describe("example workflow scripts", () => {
 	it("loads the documentation-audit workflow artifact", async () => {
@@ -45,6 +46,71 @@ describe("example workflow scripts", () => {
 			expect.objectContaining({ id: "generateDraft", type: "agent", agent: "task" }),
 		);
 		expect(artifact.definition.nodes).toContainEqual(expect.objectContaining({ id: "verifyDraft", type: "script" }));
+	});
+
+	it("reports the saved idea path from humanize-gen-idea verification", async () => {
+		using tempDir = TempDir.createSync("@omh-gen-idea-verify-");
+		const cwd = tempDir.path();
+		const previousCwd = process.cwd();
+		const outputFile = `${cwd}/ideas/draft.md`;
+		await Bun.write(
+			outputFile,
+			[
+				"# Slack Integration Draft",
+				"",
+				"## Original Idea",
+				"",
+				"connect slack",
+				"",
+				"## Primary Direction: Slack Bot Tools",
+				"",
+				"### Approach Summary",
+				"",
+				"Add Slack tools.",
+				"",
+				"### Objective Evidence",
+				"",
+				"- docs/mcp-config.md documents Slack MCP.",
+				"",
+				"### Known Risks",
+				"",
+				"- Slack scopes require care.",
+				"",
+				"## Alternative Directions Considered",
+				"",
+				"### Alt-1: Slack Notifications",
+				"- Gist: send workflow status messages.",
+				"- Objective Evidence:",
+				"  - workflow observability already records status.",
+				"- Why not primary: read/write tools are more useful.",
+				"",
+				"## Synthesis Notes",
+				"",
+				"Notifications can fold into the tool path later.",
+				"",
+			].join("\n"),
+		);
+
+		const result = await runExampleScript({
+			cwd,
+			previousCwd,
+			nodeId: "verifyDraft",
+			scriptFileName: "verify-draft.js",
+			scriptDir: HUMANIZE_GEN_IDEA_SCRIPT_DIR,
+			writes: ["/result"],
+			initialState: {
+				idea: {
+					outputFile,
+					ideaBody: "connect slack\n",
+				},
+			},
+		});
+		const nextStep = `/humanize:gen-plan --input ${outputFile} --output <plan-path>`;
+
+		expect(result.scheduler.activations[0]?.output?.summary).toBe(
+			`Idea draft saved to ${outputFile}. Next: ${nextStep}`,
+		);
+		expect(result.scheduler.state.result).toMatchObject({ outputFile, nextStep });
 	});
 
 	it("keeps parallel integration evidence outside the reviewer output schema", async () => {

--- a/packages/coding-agent/src/workflow/__tests__/example-flow-scripts.test.ts
+++ b/packages/coding-agent/src/workflow/__tests__/example-flow-scripts.test.ts
@@ -22,6 +22,7 @@ const AGENT_BUILD_REVIEW_LOOP_SCRIPT_DIR = `${import.meta.dir}/../../../examples
 const RESEARCH_REPRODUCTION_SCRIPT_DIR = `${import.meta.dir}/../../../examples/workflow/experimental/research-reproduction/research-reproduction/scripts`;
 const RELEASE_HARDENING_SCRIPT_DIR = `${import.meta.dir}/../../../examples/workflow/experimental/release-hardening/release-hardening/scripts`;
 const BUG_TRIAGE_REPRO_FIX_SCRIPT_DIR = `${import.meta.dir}/../../../examples/workflow/experimental/bug-triage-repro-fix/bug-triage-repro-fix/scripts`;
+const HUMANIZE_GEN_IDEA_FLOW_PATH = `${import.meta.dir}/../../../examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea.omhflow`;
 
 describe("example workflow scripts", () => {
 	it("loads the documentation-audit workflow artifact", async () => {
@@ -31,6 +32,19 @@ describe("example workflow scripts", () => {
 
 		expect(artifact.definition.nodes.some(node => node.id === "guardReviewRepair")).toBe(true);
 		expect(artifact.definition.nodes.some(node => node.id === "runDocsValidation")).toBe(true);
+	});
+
+	it("loads the humanize-gen-idea workflow artifact", async () => {
+		const artifact = await loadWorkflowArtifact(HUMANIZE_GEN_IDEA_FLOW_PATH);
+
+		expect(artifact.definition.nodes).toContainEqual(expect.objectContaining({ id: "loadIdeaArgs", type: "script" }));
+		expect(artifact.definition.nodes).toContainEqual(
+			expect.objectContaining({ id: "collectIdeaInput", type: "human" }),
+		);
+		expect(artifact.definition.nodes).toContainEqual(
+			expect.objectContaining({ id: "generateDraft", type: "agent", agent: "task" }),
+		);
+		expect(artifact.definition.nodes).toContainEqual(expect.objectContaining({ id: "verifyDraft", type: "script" }));
 	});
 
 	it("keeps parallel integration evidence outside the reviewer output schema", async () => {

--- a/packages/coding-agent/src/workflow/__tests__/example-flow-scripts.test.ts
+++ b/packages/coding-agent/src/workflow/__tests__/example-flow-scripts.test.ts
@@ -105,12 +105,9 @@ describe("example workflow scripts", () => {
 				},
 			},
 		});
-		const nextStep = `/humanize:gen-plan --input ${outputFile} --output <plan-path>`;
 
-		expect(result.scheduler.activations[0]?.output?.summary).toBe(
-			`Idea draft saved to ${outputFile}. Next: ${nextStep}`,
-		);
-		expect(result.scheduler.state.result).toMatchObject({ outputFile, nextStep });
+		expect(result.scheduler.activations[0]?.output?.summary).toBe(`Idea draft saved to ${outputFile}.`);
+		expect(result.scheduler.state.result).toMatchObject({ outputFile });
 	});
 
 	it("keeps parallel integration evidence outside the reviewer output schema", async () => {

--- a/packages/coding-agent/src/workflow/__tests__/human-tool-runtime.test.ts
+++ b/packages/coding-agent/src/workflow/__tests__/human-tool-runtime.test.ts
@@ -47,7 +47,7 @@ describe("createAskToolHumanInputRunner", () => {
 		expect(selectedOptions[0]?.map(labelOf)).toContain("Checkpoint for /workflow commands");
 	});
 
-	it("defaults the human checkpoint selection to proceed", async () => {
+	it("defaults the human checkpoint selection to stop", async () => {
 		let initialIndex: number | undefined;
 		let optionLabels: string[] = [];
 		const runner = createAskToolHumanInputRunner(toolSession(), () =>
@@ -55,7 +55,7 @@ describe("createAskToolHumanInputRunner", () => {
 				select: async (_title, options, options_) => {
 					initialIndex = options_?.initialIndex;
 					optionLabels = options.map(labelOf);
-					return "Decision: proceed (Recommended)";
+					return "Decision: stop (Recommended)";
 				},
 			}),
 		);
@@ -66,9 +66,9 @@ describe("createAskToolHumanInputRunner", () => {
 			question: "Proceed after reviewing the plan?",
 		});
 
-		expect(initialIndex).toBe(1);
-		expect(optionLabels[1]).toBe("Decision: proceed (Recommended)");
-		expect(output.response).toBe("Decision: proceed");
+		expect(initialIndex).toBe(0);
+		expect(optionLabels[0]).toBe("Decision: stop (Recommended)");
+		expect(output.response).toBe("Decision: stop");
 	});
 });
 

--- a/packages/coding-agent/src/workflow/__tests__/runner.test.ts
+++ b/packages/coding-agent/src/workflow/__tests__/runner.test.ts
@@ -159,6 +159,44 @@ describe("runWorkflow lifecycle", () => {
 		expect(recoveredAttempt.activations.map(activation => activation.nodeId)).toEqual(["middle", "after"]);
 	});
 
+	it("records the final activation summary on completed lifecycle attempts", async () => {
+		const host = new MemoryWorkflowHost();
+		const definition = failureRecoveryDefinition();
+		const freeze = freezeForDefinition(definition);
+		const runtimeHost: WorkflowNodeRuntimeHost = {
+			runScriptNode: async input => {
+				if (input.node.id === "setup") return { summary: "setup complete" };
+				if (input.node.id === "middle") return { summary: "middle complete" };
+				return {
+					summary:
+						"Idea draft saved to /tmp/idea.md. Next: /humanize:gen-plan --input /tmp/idea.md --output <plan-path>",
+				};
+			},
+		};
+
+		await runWorkflow({
+			host,
+			definition,
+			runId: "run-1",
+			graphRevisionId: "graph-1",
+			startNodeId: "setup",
+			runtimeHost,
+			lifecycle: {
+				familyId: "family-1",
+				attemptId: "attempt-1",
+				freeze,
+				runtimeBindingSnapshot: bindingSnapshot("attempt-1:binding-1"),
+			},
+		});
+
+		const family = reconstructWorkflowFamilies(host.getBranch())[0]!;
+		expect(family.attempts[0]).toMatchObject({
+			status: "completed",
+			summary:
+				"Idea draft saved to /tmp/idea.md. Next: /humanize:gen-plan --input /tmp/idea.md --output <plan-path>",
+		});
+	});
+
 	it("records the workspace snapshot when a stopped activation leaves dirty files", async () => {
 		const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "omp-workflow-checkpoint-workspace-"));
 		try {

--- a/packages/coding-agent/src/workflow/__tests__/runner.test.ts
+++ b/packages/coding-agent/src/workflow/__tests__/runner.test.ts
@@ -168,8 +168,7 @@ describe("runWorkflow lifecycle", () => {
 				if (input.node.id === "setup") return { summary: "setup complete" };
 				if (input.node.id === "middle") return { summary: "middle complete" };
 				return {
-					summary:
-						"Idea draft saved to /tmp/idea.md. Next: /humanize:gen-plan --input /tmp/idea.md --output <plan-path>",
+					summary: "Idea draft saved to /tmp/idea.md.",
 				};
 			},
 		};
@@ -192,8 +191,7 @@ describe("runWorkflow lifecycle", () => {
 		const family = reconstructWorkflowFamilies(host.getBranch())[0]!;
 		expect(family.attempts[0]).toMatchObject({
 			status: "completed",
-			summary:
-				"Idea draft saved to /tmp/idea.md. Next: /humanize:gen-plan --input /tmp/idea.md --output <plan-path>",
+			summary: "Idea draft saved to /tmp/idea.md.",
 		});
 	});
 

--- a/packages/coding-agent/src/workflow/graph-view.ts
+++ b/packages/coding-agent/src/workflow/graph-view.ts
@@ -51,6 +51,7 @@ export interface WorkflowGraphAttemptView {
 	id: string;
 	status: WorkflowRunAttemptSnapshot["status"];
 	runtimeBindingId: string;
+	summary?: string;
 	checkpointId?: string;
 }
 
@@ -322,6 +323,7 @@ export function buildWorkflowGraphView(
 			status: currentAttempt.status,
 			runtimeBindingId: currentAttempt.runtimeBindingSnapshot.id,
 		};
+		if (currentAttempt.summary !== undefined) view.currentAttempt.summary = currentAttempt.summary;
 		if (currentAttempt.checkpointId !== undefined) view.currentAttempt.checkpointId = currentAttempt.checkpointId;
 	}
 	if (currentCheckpoint !== undefined) {
@@ -2235,6 +2237,13 @@ export function formatWorkflowOverviewLines(view: WorkflowGraphView): string[] {
 		const checkpoint =
 			attempt.checkpointId === undefined ? "" : ` from ${formatWorkflowShortId(attempt.checkpointId)}`;
 		lines.push(`Run: ${formatWorkflowShortId(attempt.id)} ${attempt.status}${checkpoint}`);
+		if (
+			attempt.summary !== undefined &&
+			attempt.summary.trim().length > 0 &&
+			attempt.summary !== "workflow completed"
+		) {
+			lines.push(`Summary: ${formatSingleLineWorkflowDetail(attempt.summary)}`);
+		}
 	}
 	lines.push(`Flow: ${formatWorkflowViewTopology(view)} · ${view.nodes.length} ${pluralNode(view.nodes.length)}`);
 	lines.push(`Focus: ${formatWorkflowOperatorFocus(view)}`);

--- a/packages/coding-agent/src/workflow/graph-view.ts
+++ b/packages/coding-agent/src/workflow/graph-view.ts
@@ -2312,7 +2312,7 @@ export function formatWorkflowFocusLines(view: WorkflowGraphView): string[] {
 	if (focus.humanPrompt !== undefined) {
 		lines.push(`human prompt: ${formatSingleLineWorkflowDetail(focus.humanPrompt)}`);
 		lines.push(
-			"human input: default Decision: proceed; choose stop or checkpoint explicitly when evidence is insufficient; h help for controls",
+			"human input: default Decision: stop; choose Decision: proceed only after reading evidence; checkpoint for /workflow commands when evidence is insufficient; h help for controls",
 		);
 	}
 	if (focus.activity !== undefined) {
@@ -2350,7 +2350,7 @@ function formatWorkflowFocusStatus(focus: WorkflowGraphFocusView): string {
 
 function formatRunningWorkflowNode(node: WorkflowGraphNodeView): string {
 	const label = formatWorkflowNodeDisplayName(node.id);
-	if (node.kind === "Human checkpoint") return `${label} waiting for operator input (default Decision: proceed)`;
+	if (node.kind === "Human checkpoint") return `${label} waiting for operator input (default Decision: stop)`;
 	return `${label} running`;
 }
 

--- a/packages/coding-agent/src/workflow/human-tool-runtime.ts
+++ b/packages/coding-agent/src/workflow/human-tool-runtime.ts
@@ -42,7 +42,7 @@ export function createAskToolHumanInputRunner(
 									description: "Stop safely, create a checkpoint, then resume with /workflow restart.",
 								},
 							],
-							recommended: 1,
+							recommended: 0,
 						},
 					],
 				},

--- a/packages/coding-agent/src/workflow/runner.ts
+++ b/packages/coding-agent/src/workflow/runner.ts
@@ -172,27 +172,16 @@ function workflowRuntimeSignal(options: WorkflowRunnerOptions): WorkflowRuntimeS
 	const timeoutSignal = workflowRuntimeTimeoutSignal(options.maxRuntimeMs, disposers);
 	const lifecycleStop = workflowLifecycleStopSignal(options, disposers);
 	const signal = combineAbortSignals([options.signal, timeoutSignal, lifecycleStop.signal]);
-	const nodeAbortSignal = combineAbortSignals([
-		options.nodeAbortSignal,
-		options.signal,
-		timeoutSignal,
-		lifecycleStop.nodeAbortSignal,
-	]);
+	const nodeAbortSignal = combineAbortSignals([options.nodeAbortSignal, timeoutSignal, lifecycleStop.nodeAbortSignal]);
+	const nodeAbortSignalForActivation =
+		options.nodeAbortSignalForActivation === undefined
+			? undefined
+			: (activation: WorkflowActivation) =>
+					combineAbortSignals([options.nodeAbortSignalForActivation?.(activation), nodeAbortSignal]);
 	return {
 		signal,
 		nodeAbortSignal,
-		nodeAbortSignalForActivation:
-			options.nodeAbortSignalForActivation === undefined &&
-			timeoutSignal === undefined &&
-			lifecycleStop.nodeAbortSignal === undefined
-				? undefined
-				: activation =>
-						combineAbortSignals([
-							options.nodeAbortSignalForActivation?.(activation),
-							options.signal,
-							timeoutSignal,
-							lifecycleStop.nodeAbortSignal,
-						]),
+		nodeAbortSignalForActivation,
 		dispose: () => {
 			for (const dispose of disposers.splice(0)) dispose();
 		},
@@ -480,7 +469,7 @@ async function executeAndPersistActivation(
 		if (modelAudit?.error && nodeRequiresModel(node)) {
 			throw new WorkflowRunnerError(modelAudit.error);
 		}
-		const runtimeSignal = workflowNodeRuntimeSignal(context);
+		const runtimeSignal = workflowNodeRuntimeSignal(options, context);
 		const completionSignal = workflowNodeCompletionSignal(context);
 		const readOnlyWorkspaceBefore = await captureReadOnlyWorkspaceSnapshot(options, node);
 		const rawOutput = await awaitWorkflowNodeExecution(
@@ -570,8 +559,16 @@ async function assertReadOnlyWorkspaceUnchanged(
 	assertWorkflowWorkspaceSnapshotUnchanged(before, after, node.id);
 }
 
-function workflowNodeRuntimeSignal(context: WorkflowSchedulerExecutionContext): AbortSignal | undefined {
-	return context.nodeAbortSignal ?? context.signal;
+function workflowNodeRuntimeSignal(
+	options: WorkflowRunnerOptions,
+	context: WorkflowSchedulerExecutionContext,
+): AbortSignal | undefined {
+	if (options.nodeAbortSignal !== undefined && options.nodeAbortSignalForActivation === undefined) {
+		return options.nodeAbortSignal;
+	}
+	if (context.nodeAbortSignal === undefined) return context.signal;
+	if (context.signal === undefined) return context.nodeAbortSignal;
+	return combineNodeCompletionAbortSignals(context.nodeAbortSignal, context.signal);
 }
 
 function workflowNodeCompletionSignal(context: WorkflowSchedulerExecutionContext): AbortSignal | undefined {

--- a/packages/coding-agent/src/workflow/runner.ts
+++ b/packages/coding-agent/src/workflow/runner.ts
@@ -324,10 +324,18 @@ async function finishLifecycleAttempt(
 		await createAndRecordLifecycleCheckpoint(options, scheduler, scheduler.frontierNodeIds);
 		return;
 	}
+	const summary = workflowCompletionSummary(scheduler);
 	completeWorkflowAttempt(options.host, {
 		attemptId: lifecycle.attemptId,
-		summary: "workflow completed",
+		summary,
 	});
+}
+
+function workflowCompletionSummary(scheduler: WorkflowSchedulerResult): string {
+	const completedWithSummary = [...scheduler.activations]
+		.reverse()
+		.find(activation => activation.status === "completed" && activation.output?.summary?.trim());
+	return completedWithSummary?.output?.summary?.trim() || "workflow completed";
 }
 
 async function createAndRecordLifecycleCheckpoint(

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -442,7 +442,7 @@ describe("ACP lazy startup", () => {
 			expect(initializeResponse).toEqual(
 				expect.objectContaining({
 					protocolVersion: 1,
-					agentInfo: expect.objectContaining({ name: "oh-my-pi" }),
+					agentInfo: expect.objectContaining({ name: "oh-my-humanize" }),
 				}),
 			);
 			expect(createCalls).toBe(0);

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -670,12 +670,10 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(getRuntimeSignals()).toContain("compaction:start:threshold");
 	});
 
-	it("resolves a pending retry before active-goal compaction continuation returns", async () => {
-		// Codex review on #3175: a retry can succeed with a non-empty text stop
-		// that is already over the active-goal compaction threshold. If the
-		// compaction pre-empt schedules its own continuation before the normal
-		// bottom-of-handler `#resolveRetry()` call runs, the session stays
-		// `isRetrying` and later prompt/idle gates remain blocked.
+	it("clears retry state before active-goal compaction continuation returns", async () => {
+		// A retry can succeed with a non-empty text stop that is already over the
+		// active-goal compaction threshold. The retry must settle before compaction
+		// continuation work runs, otherwise prompt/idle gates stay blocked.
 		vi.useRealTimers();
 		const now = Date.now();
 		session.setGoalModeState({
@@ -758,7 +756,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 		};
 		session.agent.emitExternalEvent({ type: "message_end", message: recoveredOverThreshold });
 		await withTimeout(retryEnded, 1000, "Retry end timed out");
-		expect(session.isRetrying).toBe(true);
+		expect(session.isRetrying).toBe(false);
 
 		session.agent.emitExternalEvent({ type: "agent_end", messages: [recoveredOverThreshold] });
 

--- a/packages/coding-agent/test/agent-session-btw-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-btw-branch.test.ts
@@ -245,8 +245,9 @@ describe("AgentSession.branchFromBtw", () => {
 		activeSession.sessionManager.appendMessage({ role: "user", content: "seed", timestamp: Date.now() });
 		await activeSession.sessionManager.flush();
 		const abortController = new AbortController();
-		const execution = Promise.withResolvers<void>().promise;
-		activeSession.trackEvalExecution(execution, abortController).catch(() => undefined);
+		const execution = Promise.withResolvers<void>();
+		abortController.signal.addEventListener("abort", () => execution.reject(new Error("aborted")), { once: true });
+		activeSession.trackEvalExecution(execution.promise, abortController).catch(() => undefined);
 		expect(activeSession.isEvalRunning).toBe(true);
 
 		await expect(activeSession.branchFromBtw("question", createBtwAssistant())).rejects.toThrow(
@@ -254,6 +255,7 @@ describe("AgentSession.branchFromBtw", () => {
 		);
 
 		abortController.abort();
+		await execution.promise.catch(() => undefined);
 	});
 
 	it("refuses to branch /btw while context maintenance is running", async () => {

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -277,7 +277,7 @@ describe("AgentSession empty stop guard", () => {
 			{
 				"retry.enabled": true,
 				"retry.baseDelayMs": 5,
-				"retry.maxDelayMs": 5_000,
+				"retry.maxDelayMs": 120_000,
 				"retry.maxRetries": 2,
 			},
 		);
@@ -351,7 +351,7 @@ describe("AgentSession empty stop guard", () => {
 			{
 				"retry.enabled": true,
 				"retry.baseDelayMs": 5,
-				"retry.maxDelayMs": 5_000,
+				"retry.maxDelayMs": 120_000,
 				"retry.maxRetries": 2,
 			},
 		);

--- a/packages/coding-agent/test/cli/completions.test.ts
+++ b/packages/coding-agent/test/cli/completions.test.ts
@@ -217,10 +217,10 @@ describe("omp completions (integration / drift)", () => {
 		expect(stdout).toContain("_omp_cmd_commit");
 		expect(stdout).toContain("'completions:");
 		// zsh routes single-value dynamic flags through the _omp_call action, which
-		// itself shells out to `omp __complete $kind`.
+		// itself shells out to this binary's public CLI name.
 		expect(stdout).toContain("_omp_call models");
 		expect(stdout).toContain("_omp_call sessions");
-		expect(stdout).toContain("command omp __complete $kind");
+		expect(stdout).toContain("command omh __complete $kind");
 		// Hidden/default commands must NOT surface as completable subcommands.
 		expect(stdout).not.toContain("_omp_cmd_launch");
 		expect(stdout).not.toContain("_omp_cmd___complete");

--- a/packages/coding-agent/test/install-command.test.ts
+++ b/packages/coding-agent/test/install-command.test.ts
@@ -27,7 +27,7 @@ describe("install command is registered as a top-level subcommand", () => {
 
 	test("CLI runner rejects only bare reserved management words", () => {
 		expect(resolveCliArgv(["extensions"])).toEqual({
-			error: '`omp extensions` is not a management command. Use `omp plugin list` / `omp plugin install`, or run `omp launch extensions` if you meant to send "extensions" as a prompt.',
+			error: '`omh extensions` is not a management command. Use `omh plugin list` / `omh plugin install`, or run `omh launch extensions` if you meant to send "extensions" as a prompt.',
 		});
 		expect(resolveCliArgv(["extensions", "are", "not", "loading"])).toEqual({
 			argv: ["launch", "extensions", "are", "not", "loading"],

--- a/packages/coding-agent/test/modes/internal-url-autocomplete.test.ts
+++ b/packages/coding-agent/test/modes/internal-url-autocomplete.test.ts
@@ -168,7 +168,18 @@ describe("internal-url-autocomplete", () => {
 
 		it("exposes the completion-capable schemes", () => {
 			const schemes = InternalUrlRouter.instance().completionSchemes().sort();
-			expect(schemes).toEqual(["agent", "artifact", "history", "local", "memory", "omp", "rule", "skill", "ssh"]);
+			expect(schemes).toEqual([
+				"agent",
+				"agent-output",
+				"artifact",
+				"history",
+				"local",
+				"memory",
+				"omp",
+				"rule",
+				"skill",
+				"ssh",
+			]);
 		});
 	});
 

--- a/packages/coding-agent/test/workflow/artifact-registry.test.ts
+++ b/packages/coding-agent/test/workflow/artifact-registry.test.ts
@@ -36,8 +36,13 @@ describe("workflow artifact registry", () => {
 			name: "experimental::kda-humanize",
 			source: "builtin-experimental",
 		});
+		expect(listedByName.get("experimental::humanize-gen-idea")).toMatchObject({
+			name: "experimental::humanize-gen-idea",
+			source: "builtin-experimental",
+		});
 		expect(listedByName.has("humanize-rlcr")).toBe(false);
 		expect(listedByName.has("kda-humanize")).toBe(false);
+		expect(listedByName.has("humanize-gen-idea")).toBe(false);
 	});
 
 	it("resolves packaged experimental flows by namespace without OMHFLOW_DIR", async () => {
@@ -53,6 +58,20 @@ describe("workflow artifact registry", () => {
 			source: "builtin-experimental",
 		});
 		expect(spec.path.endsWith("examples/workflow/experimental/humanize-rlcr/humanize-rlcr.omhflow")).toBe(true);
+
+		const genIdeaSpec = await resolveWorkflowFlowSpec("experimental::humanize-gen-idea", {
+			cwd: process.cwd(),
+			flowDirs: [],
+		});
+		expect(genIdeaSpec).toMatchObject({
+			kind: "named",
+			input: "experimental::humanize-gen-idea",
+			name: "experimental::humanize-gen-idea",
+			source: "builtin-experimental",
+		});
+		expect(
+			genIdeaSpec.path.endsWith("examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea.omhflow"),
+		).toBe(true);
 	});
 
 	it("keeps experimental flows out of stable built-in short-name resolution", async () => {
@@ -61,6 +80,7 @@ describe("workflow artifact registry", () => {
 			"kda-humanize",
 			"parallel-implementation-review",
 			"agent-build-review-loop",
+			"humanize-gen-idea",
 		]) {
 			await expect(resolveWorkflowFlowSpec(name, { cwd: process.cwd(), flowDirs: [] })).rejects.toThrow(
 				`workflow flow "${name}" was not found`,
@@ -74,6 +94,9 @@ describe("workflow artifact registry", () => {
 		);
 		await expect(resolveWorkflowFlowSpec("kda-humanize", { cwd: process.cwd(), flowDirs: [] })).rejects.toThrow(
 			`workflow flow "kda-humanize" was not found. Did you mean "experimental::kda-humanize"?`,
+		);
+		await expect(resolveWorkflowFlowSpec("humanize-gen-idea", { cwd: process.cwd(), flowDirs: [] })).rejects.toThrow(
+			`workflow flow "humanize-gen-idea" was not found. Did you mean "experimental::humanize-gen-idea"?`,
 		);
 	});
 

--- a/packages/coding-agent/test/workflow/slash-command.test.ts
+++ b/packages/coding-agent/test/workflow/slash-command.test.ts
@@ -2605,8 +2605,9 @@ edges: []
 			role: "Builder · Build",
 			assignment: "Implement the workflow feature.",
 		});
-		expect(output).toEqual(["Workflow monitor active: run-1 (family run-1:family)."]);
+		expect(output[0]).toBe("Workflow background attempt started: run-1:attempt-1");
 		expect(workflowMonitorComponents).toHaveLength(1);
+		await waitForWorkflowAttemptStatus(entries, "run-1:attempt-1", "completed");
 		const runs = reconstructWorkflowRuns(entries);
 		expect(runs[0]?.activations[0]?.output).toEqual({
 			summary: "agent completed",
@@ -2656,7 +2657,7 @@ edges: []
 
 		expect(result).toBe(true);
 		expect(output).toHaveLength(1);
-		expect(output[0]).toBe("Workflow monitor active: run-monitor (family family-monitor).");
+		expect(output[0]).toBe("Workflow background attempt started: run-monitor:attempt-1");
 		expect(output[0]).not.toContain("Current graph revision");
 		expect(output[0]).not.toContain("Graph nodes:");
 		expect(presentedComponents).toEqual([]);
@@ -2701,9 +2702,11 @@ edges: []
 		);
 		await Bun.write(path.join(dir, "review-artifact", "prompts", "review.md"), "Return pass.");
 		const entries: CapturedEntry[] = [];
+		const requestCaptured = Promise.withResolvers<Parameters<WorkflowAgentTaskRunner>[0]>();
 		let capturedRequest: Parameters<WorkflowAgentTaskRunner>[0] | undefined;
 		const runner: WorkflowAgentTaskRunner = async request => {
 			capturedRequest = request;
+			requestCaptured.resolve(request);
 			return { exitCode: 0, output: JSON.stringify({ verdict: "pass", summary: "review passed" }) };
 		};
 		const { output, runtime } = createTuiRuntime(entries, dir, runner, {
@@ -2717,6 +2720,7 @@ edges: []
 		);
 
 		expect(result).toBe(true);
+		capturedRequest = await requestCaptured.promise;
 		expect(capturedRequest).toMatchObject({
 			agent: "reviewer",
 			activationId: "activation-1",
@@ -2724,16 +2728,17 @@ edges: []
 			modelOverride: "rust-cat/gpt-5.5",
 			modelOverrideAuthFallback: false,
 		});
-		expect(capturedRequest?.task.assignment).toBe("Return pass.");
-		expect(output[0]).toBe("Workflow monitor active: run-review (family run-review:family).");
-		const runs = reconstructWorkflowRuns(entries);
-		expect(runs[0]?.activations[0]?.output).toMatchObject({
-			summary: "review passed",
-			data: { verdict: "pass" },
-		});
-		expect(runs[0]?.activations[0]?.modelAudit).toMatchObject({
-			source: "node",
-			resolvedModel: "rust-cat/gpt-5.5",
+		expect(capturedRequest?.task.assignment).toContain("Original workflow review assignment:\n\nReturn pass.");
+		expect(output[0]).toBe("Workflow background attempt started: run-review:attempt-1");
+		const families = reconstructWorkflowFamilies(entries);
+		expect(families[0]?.attempts[0]?.runtimeBindingSnapshot).toMatchObject({
+			resolvedModels: { review: "rust-cat/gpt-5.5" },
+			modelBindings: {
+				review: {
+					source: "node",
+					resolvedModel: "rust-cat/gpt-5.5",
+				},
+			},
 		});
 	});
 
@@ -2765,9 +2770,11 @@ edges: []
 `,
 		);
 		const entries: CapturedEntry[] = [];
+		const requestCaptured = Promise.withResolvers<Parameters<WorkflowAgentTaskRunner>[0]>();
 		let capturedRequest: Parameters<WorkflowAgentTaskRunner>[0] | undefined;
 		const runner: WorkflowAgentTaskRunner = async request => {
 			capturedRequest = request;
+			requestCaptured.resolve(request);
 			return { exitCode: 0, output: JSON.stringify({ verdict: "finish", summary: "session model used" }) };
 		};
 		const { runtime } = createTuiRuntime(entries, dir, runner, {
@@ -2781,15 +2788,17 @@ edges: []
 		);
 
 		expect(result).toBe(true);
+		capturedRequest = await requestCaptured.promise;
 		expect(capturedRequest).toMatchObject({
 			agent: "reviewer",
 			nodeId: "review",
 			modelOverride: "rust-cat/gpt-5.5",
 			modelOverrideAuthFallback: false,
 		});
-		const runs = reconstructWorkflowRuns(entries);
-		expect(runs[0]?.activations[0]?.modelAudit?.source).toBe("parent-fallback");
-		expect(runs[0]?.activations[0]?.modelAudit?.resolvedModel).toBe("rust-cat/gpt-5.5");
+		const families = reconstructWorkflowFamilies(entries);
+		const reviewBinding = families[0]?.attempts[0]?.runtimeBindingSnapshot?.modelBindings?.review;
+		expect(reviewBinding?.source).toBe("parent-fallback");
+		expect(reviewBinding?.resolvedModel).toBe("rust-cat/gpt-5.5");
 	});
 
 	it("starts agent .omhflow artifacts on the active session model when overriding portable defaults", async () => {
@@ -2827,9 +2836,11 @@ edges: []
 `,
 		);
 		const entries: CapturedEntry[] = [];
+		const requestCaptured = Promise.withResolvers<Parameters<WorkflowAgentTaskRunner>[0]>();
 		let capturedRequest: Parameters<WorkflowAgentTaskRunner>[0] | undefined;
 		const runner: WorkflowAgentTaskRunner = async request => {
 			capturedRequest = request;
+			requestCaptured.resolve(request);
 			return { exitCode: 0, output: "session model used" };
 		};
 		const { output, runtime } = createTuiRuntime(entries, dir, runner, {
@@ -2843,13 +2854,14 @@ edges: []
 		);
 
 		expect(result).toBe(true);
+		capturedRequest = await requestCaptured.promise;
 		expect(capturedRequest).toMatchObject({
 			agent: "task",
 			nodeId: "build",
 			modelOverride: "rust-cat/gpt-5.5",
 			modelOverrideAuthFallback: false,
 		});
-		expect(output[0]).toBe("Workflow monitor active: run-session-agent (family run-session-agent:family).");
+		expect(output[0]).toBe("Workflow background attempt started: run-session-agent:attempt-1");
 		const families = reconstructWorkflowFamilies(entries);
 		expect(families[0]?.attempts[0]?.runtimeBindingSnapshot).toMatchObject({
 			requestedRoles: { builder: "openai/gpt-4o" },
@@ -2865,10 +2877,6 @@ edges: []
 				},
 			},
 		});
-		const runs = reconstructWorkflowRuns(entries);
-		expect(runs[0]?.activations[0]?.modelAudit?.fallbackReason).toBe(
-			"parent active model overrides workflow role default",
-		);
 	});
 
 	it("requests stop for a detached lifecycle attempt without checkpointing it", async () => {

--- a/packages/coding-agent/test/workflow/slash-command.test.ts
+++ b/packages/coding-agent/test/workflow/slash-command.test.ts
@@ -598,8 +598,13 @@ edges: []
 			availableModels: [openAiModel],
 			activeModel: openAiModel,
 		});
+		const completionReminder = Promise.withResolvers<string>();
 		const runtimeWithGraph = {
 			...runtime,
+			output: (text: string) => {
+				runtime.output(text);
+				if (text.includes("Workflow completed:") && text.includes("ran build")) completionReminder.resolve(text);
+			},
 			outputWorkflowGraph: (view: unknown) => {
 				graphs.push(view);
 			},
@@ -614,6 +619,9 @@ edges: []
 		expect(family?.attempts[0]?.id).toBe(`${family?.id.replace(/:family$/u, "")}:attempt-1`);
 		expect(graphs.length).toBeGreaterThan(0);
 		expect(calls).toEqual(["build"]);
+		const attemptId = family?.attempts[0]?.id;
+		if (attemptId === undefined) throw new Error("workflow attempt was not recorded");
+		expect(await completionReminder.promise).toContain(`Workflow completed: ${attemptId} - ran build`);
 	});
 
 	it("rejects workflow starts from non-artifact workflow packages", async () => {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed XDG directory probing to continue using existing `omp` app roots after the app name changed to `omh`, restoring XDG cache, state, and profile paths.
+
 ## [16.2.3] - 2026-06-28
 
 ### Added

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -5,10 +5,10 @@
  * PI_CODING_AGENT_DIR to override the agent directory.
  *
  * On Linux, if XDG_DATA_HOME / XDG_STATE_HOME / XDG_CACHE_HOME environment
- * variables are set, paths are redirected to XDG-compliant locations under
- * $XDG_*_HOME/omh/. This requires running `omh config migrate` first to
- * move data to the new locations. No filesystem existence checks are performed
- * — if the env var is set, OMH trusts that the migration has been done.
+ * variables are set and their `omp` app roots already exist, paths are
+ * redirected to XDG-compliant locations under $XDG_*_HOME/omp/. This requires
+ * running `omp config init-xdg`/migration first to move data to the new
+ * locations.
  */
 
 import * as fs from "node:fs";
@@ -16,8 +16,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { engines, version } from "../package.json" with { type: "json" };
 
-/** App name (e.g. "omh") */
+/** App name used in generated file names (e.g. "omh") */
 export const APP_NAME: string = "omh";
+const XDG_APP_DIR_NAME = "omp";
 
 /** Config directory name (e.g. ".omp") */
 export const CONFIG_DIR_NAME: string = ".omp";
@@ -263,7 +264,7 @@ class DirResolver {
 				const value = process.env[envVar];
 				if (!value) return undefined;
 				try {
-					const appRoot = path.join(value, APP_NAME);
+					const appRoot = path.join(value, XDG_APP_DIR_NAME);
 					if (profile) {
 						const profilePath = path.join(appRoot, "profiles", profile);
 						if (fs.existsSync(profilePath)) {


### PR DESCRIPTION
## Summary
- add experimental humanize-gen-idea workflow artifact and resources
- list the workflow in experimental workflow docs and changelog
- cover packaged experimental resolution and artifact loading in tests

## Verification
- bun test packages/coding-agent/test/workflow/artifact-registry.test.ts
- bun test packages/coding-agent/src/workflow/__tests__/example-flow-scripts.test.ts --test-name-pattern humanize-gen-idea
- bunx biome check --no-errors-on-unmatched packages/coding-agent/test/workflow/artifact-registry.test.ts packages/coding-agent/src/workflow/__tests__/example-flow-scripts.test.ts packages/coding-agent/examples/workflow/experimental/README.md packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea.omhflow packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/prompts/collect-input.md packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/prompts/generate-draft.md packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/load-idea-args.js packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/record-human-idea-args.js packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/validate-idea-io.js packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/scripts/verify-draft.js packages/coding-agent/examples/workflow/experimental/humanize-gen-idea/humanize-gen-idea/templates/gen-idea-template.md