### PR TITLE
Add headless Claude login flows

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Anthropic Claude subscription and Console pasted-code OAuth login providers, including fixed platform redirect handling and account identity propagation for token responses.
+
 ## [16.2.5] - 2026-06-28
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic-version.ts
+++ b/packages/ai/src/providers/anthropic-version.ts
@@ -1,0 +1,1 @@
+export const claudeCodeVersion = "2.1.165";

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -71,6 +71,7 @@ import {
 	calculateAnthropicRetryDelayMs,
 	retryDelayFromHeaders,
 } from "./anthropic-client";
+import { claudeCodeVersion } from "./anthropic-version";
 import type {
 	ToolInputSchema as AnthropicToolInputSchema,
 	Tool as AnthropicWireTool,
@@ -419,7 +420,7 @@ function getCacheControl(
 }
 
 // Stealth mode: mimic Claude Code's request fingerprint.
-export const claudeCodeVersion = "2.1.165";
+export { claudeCodeVersion };
 export const claudeAgentSdkVersion = "0.3.165";
 export const claudeClientVersion = "1.11187.4";
 export const claudeToolPrefix: string = "_";

--- a/packages/ai/src/registry/anthropic.ts
+++ b/packages/ai/src/registry/anthropic.ts
@@ -1,5 +1,6 @@
 import { $pickenv } from "@oh-my-pi/pi-utils";
 import { isFoundryEnabled } from "../utils/foundry";
+import { loginAnthropic, loginAnthropicCode, refreshAnthropicToken } from "./oauth/anthropic";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
 
@@ -11,16 +12,26 @@ export const anthropicProvider = {
 		isFoundryEnabled()
 			? $pickenv("ANTHROPIC_FOUNDRY_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
 			: $pickenv("ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
-	login: async (cb: OAuthLoginCallbacks) => {
-		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
-		const { loginAnthropic } = await import("./oauth/anthropic");
-		return loginAnthropic(cb);
-	},
-	refreshToken: async (credentials: OAuthCredentials) => {
-		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
-		const { refreshAnthropicToken } = await import("./oauth/anthropic");
-		return refreshAnthropicToken(credentials.refresh);
-	},
+	login: async (cb: OAuthLoginCallbacks) => loginAnthropic(cb),
+	refreshToken: async (credentials: OAuthCredentials) => refreshAnthropicToken(credentials.refresh),
 	callbackPort: 54545,
+	pasteCodeFlow: true,
+} as const satisfies ProviderDefinition;
+
+export const anthropicCodeProvider = {
+	id: "anthropic-code",
+	name: "Anthropic Claude subscription (login code)",
+	login: async (cb: OAuthLoginCallbacks) => loginAnthropicCode(cb, "claudeai"),
+	refreshToken: async (credentials: OAuthCredentials) => refreshAnthropicToken(credentials.refresh),
+	storeCredentialsAs: "anthropic",
+	pasteCodeFlow: true,
+} as const satisfies ProviderDefinition;
+
+export const anthropicConsoleProvider = {
+	id: "anthropic-console",
+	name: "Anthropic Console (login code)",
+	login: async (cb: OAuthLoginCallbacks) => loginAnthropicCode(cb, "console"),
+	refreshToken: async (credentials: OAuthCredentials) => refreshAnthropicToken(credentials.refresh),
+	storeCredentialsAs: "anthropic",
 	pasteCodeFlow: true,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/oauth/anthropic.ts
+++ b/packages/ai/src/registry/oauth/anthropic.ts
@@ -2,27 +2,32 @@
  * Anthropic OAuth flow (Claude Pro/Max)
  */
 
+import { z } from "zod/v4";
 import * as AIError from "../../error";
-import { claudeCodeVersion } from "../../providers/anthropic";
+import { claudeCodeVersion } from "../../providers/anthropic-version";
 import type { FetchImpl } from "../../types";
-import { OAuthCallbackFlow } from "./callback-server";
+import { OAuthCallbackFlow, parseCallbackInput } from "./callback-server";
 import { generatePKCE } from "./pkce";
 import type { OAuthController, OAuthCredentials } from "./types";
 
 const decode = (s: string) => atob(s);
 const CLIENT_ID = decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl");
-const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
+const LOOPBACK_AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
+const CLAUDEAI_CODE_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize";
+const CONSOLE_AUTHORIZE_URL = "https://platform.claude.com/oauth/authorize";
 const TOKEN_URL = "https://api.anthropic.com/v1/oauth/token";
 const BOOTSTRAP_URL = "https://api.anthropic.com/api/claude_cli/bootstrap";
 const CLAUDE_CODE_BOOTSTRAP_MODEL = "claude-opus-4-8";
 const CLAUDE_CODE_BOOTSTRAP_USER_AGENT = `claude-code/${claudeCodeVersion}`;
 const CALLBACK_PORT = 54545;
 const CALLBACK_PATH = "/callback";
+const CODE_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback";
 // Scopes required for direct OAuth-token inference (user:inference) plus account/session management.
-// platform.claude.com/oauth/authorize issues console tokens (org:create_api_key only) and does not
-// grant user:inference — the claude.ai endpoint is required for direct inference access.
+// Claude Code uses the same requested scope set for both browser callback and pasted-code logins.
 const SCOPES =
 	"org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+
+export type AnthropicCodeLoginSource = "claudeai" | "console";
 
 function formatErrorDetails(error: unknown): string {
 	if (error instanceof Error) {
@@ -68,29 +73,40 @@ async function postJson(
 	return responseBody;
 }
 
-/**
- * Decoded shape of Anthropic's `/v1/oauth/token` response (both
- * `authorization_code` exchange and `refresh_token` refresh return the same
- * envelope). Newer responses inline `account`; older/stale credentials can
- * recover the same identity from `/api/claude_cli/bootstrap`.
- */
-interface AnthropicTokenResponse {
-	access_token: string;
-	refresh_token: string;
-	expires_in: number;
-	account?: { uuid?: string; email_address?: string };
-}
+const AnthropicTokenResponseSchema = z
+	.object({
+		access_token: z.string(),
+		refresh_token: z.string(),
+		expires_in: z.number(),
+		account: z
+			.object({
+				uuid: z.string().optional(),
+				email_address: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
 
-interface AnthropicBootstrapResponse {
-	oauth_account?: {
-		account_uuid?: string;
-		account_email?: string;
-	};
-}
+type AnthropicTokenResponse = z.infer<typeof AnthropicTokenResponseSchema>;
+
+const AnthropicBootstrapResponseSchema = z
+	.object({
+		oauth_account: z
+			.object({
+				account_uuid: z.string().optional(),
+				account_email: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
+
+type AnthropicBootstrapResponse = z.infer<typeof AnthropicBootstrapResponseSchema>;
 
 function parseOAuthTokenResponse(responseBody: string, operation: string): AnthropicTokenResponse {
 	try {
-		return JSON.parse(responseBody) as AnthropicTokenResponse;
+		return AnthropicTokenResponseSchema.parse(JSON.parse(responseBody));
 	} catch (error) {
 		throw new AIError.OAuthError(
 			`Anthropic ${operation} returned invalid JSON. url=${TOKEN_URL}; body=${responseBody}; details=${formatErrorDetails(error)}`,
@@ -143,7 +159,7 @@ async function fetchBootstrapIdentity(
 	}
 	let data: AnthropicBootstrapResponse;
 	try {
-		data = JSON.parse(responseBody) as AnthropicBootstrapResponse;
+		data = AnthropicBootstrapResponseSchema.parse(JSON.parse(responseBody));
 	} catch (error) {
 		throw new AIError.OAuthError(
 			`Anthropic bootstrap returned invalid JSON. url=${url}; body=${responseBody}; details=${formatErrorDetails(error)}`,
@@ -175,6 +191,74 @@ async function resolveAccountIdentity(
 	}
 }
 
+function generateState(): string {
+	const bytes = new Uint8Array(16);
+	crypto.getRandomValues(bytes);
+	return Array.from(bytes)
+		.map(value => value.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+function buildAnthropicAuthorizeUrl(
+	authorizeUrl: string,
+	state: string,
+	redirectUri: string,
+	challenge: string,
+): string {
+	const authParams = new URLSearchParams({
+		code: "true",
+		client_id: CLIENT_ID,
+		response_type: "code",
+		redirect_uri: redirectUri,
+		scope: SCOPES,
+		code_challenge: challenge,
+		code_challenge_method: "S256",
+		state,
+	});
+	return `${authorizeUrl}?${authParams.toString()}`;
+}
+
+function normalizeAuthorizationCodeInput(code: string, state: string): { code: string; state: string } {
+	const parsed = parseCallbackInput(code);
+	return {
+		code: parsed.code ?? code,
+		state: parsed.state && parsed.state.length > 0 ? parsed.state : state,
+	};
+}
+
+async function exchangeAnthropicAuthorizationCode(args: {
+	code: string;
+	state: string;
+	redirectUri: string;
+	verifier: string;
+	fetchImpl: FetchImpl;
+}): Promise<AnthropicTokenResponse> {
+	const { code, state, redirectUri, verifier, fetchImpl } = args;
+	const normalized = normalizeAuthorizationCodeInput(code, state);
+	let responseBody: string;
+	try {
+		responseBody = await postJson(
+			TOKEN_URL,
+			{
+				grant_type: "authorization_code",
+				client_id: CLIENT_ID,
+				code: normalized.code,
+				state: normalized.state,
+				redirect_uri: redirectUri,
+				code_verifier: verifier,
+			},
+			fetchImpl,
+		);
+	} catch (error) {
+		throw new AIError.OAuthError(
+			`Token exchange request failed. url=${TOKEN_URL}; redirect_uri=${redirectUri}; response_type=authorization_code; details=${formatErrorDetails(error)}`,
+			{ kind: "token-exchange", provider: "anthropic", cause: error },
+		);
+	}
+
+	return parseOAuthTokenResponse(responseBody, "token exchange");
+}
+
 export class AnthropicOAuthFlow extends OAuthCallbackFlow {
 	#verifier: string = "";
 	#challenge: string = "";
@@ -190,17 +274,7 @@ export class AnthropicOAuthFlow extends OAuthCallbackFlow {
 		this.#verifier = pkce.verifier;
 		this.#challenge = pkce.challenge;
 
-		const authParams = new URLSearchParams({
-			code: "true",
-			client_id: CLIENT_ID,
-			response_type: "code",
-			redirect_uri: redirectUri,
-			scope: SCOPES,
-			code_challenge: this.#challenge,
-			code_challenge_method: "S256",
-			state,
-		});
-		const url = `${AUTHORIZE_URL}?${authParams.toString()}`;
+		const url = buildAnthropicAuthorizeUrl(LOOPBACK_AUTHORIZE_URL, state, redirectUri, this.#challenge);
 
 		return {
 			url,
@@ -210,39 +284,13 @@ export class AnthropicOAuthFlow extends OAuthCallbackFlow {
 	}
 
 	async exchangeToken(code: string, state: string, redirectUri: string): Promise<OAuthCredentials> {
-		let exchangeCode = code;
-		let exchangeState = state;
-		const codeFragmentIndex = code.indexOf("#");
-		if (codeFragmentIndex >= 0) {
-			exchangeCode = code.slice(0, codeFragmentIndex);
-			const codeFragmentState = code.slice(codeFragmentIndex + 1);
-			if (codeFragmentState.length > 0) {
-				exchangeState = codeFragmentState;
-			}
-		}
-
-		let responseBody: string;
-		try {
-			responseBody = await postJson(
-				TOKEN_URL,
-				{
-					grant_type: "authorization_code",
-					client_id: CLIENT_ID,
-					code: exchangeCode,
-					state: exchangeState,
-					redirect_uri: redirectUri,
-					code_verifier: this.#verifier,
-				},
-				this.#fetch,
-			);
-		} catch (error) {
-			throw new AIError.OAuthError(
-				`Token exchange request failed. url=${TOKEN_URL}; redirect_uri=${redirectUri}; response_type=authorization_code; details=${formatErrorDetails(error)}`,
-				{ kind: "token-exchange", provider: "anthropic", cause: error },
-			);
-		}
-
-		const tokenData = parseOAuthTokenResponse(responseBody, "token exchange");
+		const tokenData = await exchangeAnthropicAuthorizationCode({
+			code,
+			state,
+			redirectUri,
+			verifier: this.#verifier,
+			fetchImpl: this.#fetch,
+		});
 		const { accountId, email } = await resolveAccountIdentity(tokenData, this.#fetch);
 
 		return {
@@ -255,11 +303,105 @@ export class AnthropicOAuthFlow extends OAuthCallbackFlow {
 	}
 }
 
+export class AnthropicCodeOAuthFlow {
+	#verifier: string = "";
+	#challenge: string = "";
+	#fetch: FetchImpl;
+	#source: AnthropicCodeLoginSource;
+	ctrl: OAuthController;
+
+	constructor(ctrl: OAuthController, source: AnthropicCodeLoginSource) {
+		this.ctrl = ctrl;
+		this.#source = source;
+		this.#fetch = ctrl.fetch ?? fetch;
+	}
+
+	async generateAuthUrl(state: string): Promise<{ url: string; instructions?: string }> {
+		const pkce = await generatePKCE();
+		this.#verifier = pkce.verifier;
+		this.#challenge = pkce.challenge;
+
+		const authorizeUrl = this.#source === "console" ? CONSOLE_AUTHORIZE_URL : CLAUDEAI_CODE_AUTHORIZE_URL;
+		const label = this.#source === "console" ? "Anthropic Console" : "Claude";
+		return {
+			url: buildAnthropicAuthorizeUrl(authorizeUrl, state, CODE_REDIRECT_URI, this.#challenge),
+			instructions: `Complete ${label} login in a browser, then paste the authorization code shown by Anthropic.`,
+		};
+	}
+
+	async exchangeToken(code: string, state: string): Promise<OAuthCredentials> {
+		const tokenData = await exchangeAnthropicAuthorizationCode({
+			code,
+			state,
+			redirectUri: CODE_REDIRECT_URI,
+			verifier: this.#verifier,
+			fetchImpl: this.#fetch,
+		});
+		const { accountId, email } = await resolveAccountIdentity(tokenData, this.#fetch);
+
+		return {
+			refresh: tokenData.refresh_token,
+			access: tokenData.access_token,
+			expires: Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000,
+			accountId,
+			email,
+		};
+	}
+
+	async login(): Promise<OAuthCredentials> {
+		const state = generateState();
+		const { url, instructions } = await this.generateAuthUrl(state);
+		this.ctrl.onAuth?.({ url, instructions });
+		this.ctrl.onProgress?.("Waiting for pasted authorization code...");
+		const input = await this.#waitForCode(state);
+		this.ctrl.onProgress?.("Exchanging authorization code for tokens...");
+		return this.exchangeToken(input.code, input.state);
+	}
+
+	async #waitForCode(expectedState: string): Promise<{ code: string; state: string }> {
+		while (true) {
+			if (this.ctrl.signal?.aborted) {
+				throw new AIError.LoginCancelledError(`OAuth login cancelled: ${this.ctrl.signal.reason}`);
+			}
+			const input = await this.#readCodeInput();
+			const parsed = parseCallbackInput(input);
+			if (!parsed.code) {
+				this.ctrl.onProgress?.("No authorization code found in pasted input. Try again.");
+				continue;
+			}
+			if (parsed.state && parsed.state !== expectedState) {
+				this.ctrl.onProgress?.("Pasted authorization state did not match this login attempt. Try again.");
+				continue;
+			}
+			return { code: parsed.code, state: parsed.state ?? expectedState };
+		}
+	}
+
+	#readCodeInput(): Promise<string> {
+		if (this.ctrl.onManualCodeInput) return this.ctrl.onManualCodeInput();
+		if (this.ctrl.onPrompt) {
+			return this.ctrl.onPrompt({ message: "Paste the authorization code (or full redirect URL):" });
+		}
+		throw new AIError.ConfigurationError("Anthropic pasted-code OAuth requires a manual code input callback.");
+	}
+}
+
 /**
- * Login with Anthropic OAuth
+ * Login with Anthropic OAuth using a local callback server.
  */
 export async function loginAnthropic(ctrl: OAuthController): Promise<OAuthCredentials> {
 	const flow = new AnthropicOAuthFlow(ctrl);
+	return flow.login();
+}
+
+/**
+ * Login with Anthropic OAuth using Claude Code's pasted-code redirect page.
+ */
+export async function loginAnthropicCode(
+	ctrl: OAuthController,
+	source: AnthropicCodeLoginSource = "claudeai",
+): Promise<OAuthCredentials> {
+	const flow = new AnthropicCodeOAuthFlow(ctrl, source);
 	return flow.login();
 }
 

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -2,7 +2,7 @@ import type { KnownProvider } from "@oh-my-pi/pi-catalog";
 import { aimlApiProvider } from "./aimlapi";
 import { alibabaCodingPlanProvider } from "./alibaba-coding-plan";
 import { amazonBedrockProvider } from "./amazon-bedrock";
-import { anthropicProvider } from "./anthropic";
+import { anthropicCodeProvider, anthropicConsoleProvider, anthropicProvider } from "./anthropic";
 import { azureProvider } from "./azure";
 import { cerebrasProvider } from "./cerebras";
 import { cloudflareAiGatewayProvider } from "./cloudflare-ai-gateway";
@@ -77,6 +77,8 @@ const ALL = [
 	azureProvider,
 	openaiCodexProvider,
 	anthropicProvider,
+	anthropicConsoleProvider,
+	anthropicCodeProvider,
 	zaiProvider,
 	kimiCodeProvider,
 	openrouterProvider,

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -1,7 +1,7 @@
 import { scheduler } from "node:timers/promises";
 import { toNumber } from "@oh-my-pi/pi-catalog/utils";
 import * as AIError from "../error";
-import { claudeCodeVersion } from "../providers/anthropic";
+import { claudeCodeVersion } from "../providers/anthropic-version";
 import type {
 	CredentialRankingStrategy,
 	UsageAmount,

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/anthropic";
-import { AnthropicOAuthFlow, refreshAnthropicToken } from "@oh-my-pi/pi-ai/registry/oauth/anthropic";
+import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/anthropic-version";
+import {
+	AnthropicCodeOAuthFlow,
+	AnthropicOAuthFlow,
+	refreshAnthropicToken,
+} from "@oh-my-pi/pi-ai/registry/oauth/anthropic";
 import {
 	buildAnthropicAuthConfig,
 	buildAnthropicSearchHeaders,
@@ -27,6 +31,35 @@ describe("anthropic oauth alignment", () => {
 		);
 		expect(authUrl.searchParams.get("state")).toBe(state);
 		expect(authUrl.searchParams.get("redirect_uri")).toBe(redirectUri);
+		expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+	});
+
+	it("generates Console code auth URL with fixed platform callback", async () => {
+		const flow = new AnthropicCodeOAuthFlow({}, "console");
+		const state = "state-console";
+
+		const { url } = await flow.generateAuthUrl(state);
+		const authUrl = new URL(url);
+
+		expect(authUrl.origin + authUrl.pathname).toBe("https://platform.claude.com/oauth/authorize");
+		expect(authUrl.searchParams.get("scope")).toBe(
+			"org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
+		);
+		expect(authUrl.searchParams.get("state")).toBe(state);
+		expect(authUrl.searchParams.get("redirect_uri")).toBe("https://platform.claude.com/oauth/code/callback");
+		expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+	});
+
+	it("generates Claude code auth URL with fixed platform callback", async () => {
+		const flow = new AnthropicCodeOAuthFlow({}, "claudeai");
+		const state = "state-claudeai";
+
+		const { url } = await flow.generateAuthUrl(state);
+		const authUrl = new URL(url);
+
+		expect(authUrl.origin + authUrl.pathname).toBe("https://claude.com/cai/oauth/authorize");
+		expect(authUrl.searchParams.get("state")).toBe(state);
+		expect(authUrl.searchParams.get("redirect_uri")).toBe("https://platform.claude.com/oauth/code/callback");
 		expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
 	});
 
@@ -108,6 +141,39 @@ describe("anthropic oauth alignment", () => {
 		await flow.generateAuthUrl("state-123", "http://localhost:54545/callback");
 		await flow.exchangeToken("code-123#", "state-explicit", "http://localhost:54545/callback");
 
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("exchanges pasted Console callback URL with fixed platform redirect", async () => {
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			expect(typeof input === "string" ? input : input.toString()).toBe("https://api.anthropic.com/v1/oauth/token");
+			const payload = JSON.parse(String(init?.body));
+			expect(payload.code).toBe("code-123");
+			expect(payload.state).toBe("state-url");
+			expect(payload.redirect_uri).toBe("https://platform.claude.com/oauth/code/callback");
+			return new Response(
+				JSON.stringify({
+					access_token: "access-token",
+					refresh_token: "refresh-token",
+					expires_in: 3600,
+					account: {
+						uuid: "11111111-2222-3333-4444-555555555555",
+						email_address: "user@example.com",
+					},
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		const flow = new AnthropicCodeOAuthFlow({ fetch: fetchMock as unknown as typeof fetch }, "console");
+		await flow.generateAuthUrl("state-console");
+		const result = await flow.exchangeToken(
+			"https://platform.claude.com/oauth/code/callback?code=code-123&state=state-url",
+			"state-console",
+		);
+
+		expect(result.access).toBe("access-token");
+		expect(result.refresh).toBe("refresh-token");
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 	it("uses api.anthropic.com token URL and CC headers for refresh", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Claude subscription and Anthropic Console headless auth-broker login modes, plus Claude Code credential JSON import support.
+
 ### Fixed
+
+- Fixed pasted OAuth login codes submitted in the TUI being sent to the agent instead of the pending login flow.
 
 - Fixed the experimental performance-optimization-search flow treating a committed positive selection with a clean worktree as a no-win outcome during finalize/archive.
 - Fixed the experimental research-reproduction flow assuming comparison agent summaries automatically materialized `/comparison` before review prompts.

--- a/packages/coding-agent/src/cli/__tests__/auth-broker-cli.test.ts
+++ b/packages/coding-agent/src/cli/__tests__/auth-broker-cli.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import { __resetDirsFromEnvForTests, getAgentDbPath, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { z } from "zod/v4";
+import { runAuthBrokerCommand } from "../auth-broker-cli";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+const AuthBrokerJsonOutputSchema = z.object({
+	dryRun: z.boolean().optional(),
+	imported: z.array(z.object({ provider: z.string(), email: z.string().nullable().optional(), file: z.string() })),
+	plan: z.array(
+		z.object({
+			provider: z.string(),
+			email: z.string().nullable(),
+			accountId: z.string().nullable(),
+			expiresAt: z.number(),
+			disabled: z.boolean(),
+			file: z.string(),
+		}),
+	),
+	skipped: z.array(z.object({ file: z.string(), reason: z.string() })),
+});
+
+describe("auth-broker import", () => {
+	it("imports Claude Code credentials JSON as an Anthropic OAuth credential", async () => {
+		using tempDir = TempDir.createSync("@omp-auth-broker-import-claude-");
+		const root = tempDir.path();
+		const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const originalBrokerUrl = process.env.OMP_AUTH_BROKER_URL;
+		const originalBrokerToken = process.env.OMP_AUTH_BROKER_TOKEN;
+		const stdout: string[] = [];
+		const expiresAt = Date.now() + 60 * 60 * 1000;
+		const source = `${root}/.claude/.credentials.json`;
+
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			stdout.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+			return true;
+		});
+
+		setAgentDir(`${root}/agent`);
+		delete process.env.OMP_AUTH_BROKER_URL;
+		delete process.env.OMP_AUTH_BROKER_TOKEN;
+
+		try {
+			await Bun.write(
+				source,
+				JSON.stringify({
+					claudeAiOauth: {
+						accessToken: "claude-access-secret",
+						refreshToken: "claude-refresh-secret",
+						expiresAt,
+						scopes: ["org:create_api_key", "user:profile", "user:inference"],
+						account: {
+							uuid: "account-123",
+							email_address: "user@example.com",
+						},
+					},
+				}),
+			);
+
+			await runAuthBrokerCommand({
+				action: "import",
+				flags: { source, json: true },
+			});
+
+			const output = stdout.join("");
+			expect(output).not.toContain("claude-access-secret");
+			expect(output).not.toContain("claude-refresh-secret");
+			const result = AuthBrokerJsonOutputSchema.parse(JSON.parse(output));
+			expect(result.skipped).toEqual([]);
+			expect(result.imported).toEqual([{ provider: "anthropic", email: "user@example.com", file: source }]);
+			expect(result.plan).toEqual([
+				{
+					provider: "anthropic",
+					email: "user@example.com",
+					accountId: "account-123",
+					expiresAt,
+					disabled: false,
+					file: source,
+				},
+			]);
+
+			const store = await SqliteAuthCredentialStore.open(getAgentDbPath());
+			try {
+				const rows = store.listAuthCredentials("anthropic");
+				expect(rows).toHaveLength(1);
+				expect(rows[0]?.credential).toEqual({
+					type: "oauth",
+					access: "claude-access-secret",
+					refresh: "claude-refresh-secret",
+					expires: expiresAt,
+					email: "user@example.com",
+					accountId: "account-123",
+				});
+			} finally {
+				store.close();
+			}
+		} finally {
+			if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+			if (originalBrokerUrl === undefined) delete process.env.OMP_AUTH_BROKER_URL;
+			else process.env.OMP_AUTH_BROKER_URL = originalBrokerUrl;
+			if (originalBrokerToken === undefined) delete process.env.OMP_AUTH_BROKER_TOKEN;
+			else process.env.OMP_AUTH_BROKER_TOKEN = originalBrokerToken;
+			__resetDirsFromEnvForTests();
+		}
+	});
+
+	it("dry-runs Claude Code credentials without identity metadata", async () => {
+		using tempDir = TempDir.createSync("@omp-auth-broker-import-claude-dry-run-");
+		const source = `${tempDir.path()}/.credentials.json`;
+		const stdout: string[] = [];
+		const expiresAt = Date.now() + 2 * 60 * 60 * 1000;
+
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			stdout.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+			return true;
+		});
+
+		await Bun.write(
+			source,
+			JSON.stringify({
+				claudeAiOauth: {
+					accessToken: "opaque-access-token",
+					refreshToken: "opaque-refresh-token",
+					expiresAt,
+					scopes: ["user:inference"],
+				},
+			}),
+		);
+
+		await runAuthBrokerCommand({
+			action: "import",
+			flags: { source, json: true, dryRun: true },
+		});
+
+		const output = stdout.join("");
+		expect(output).not.toContain("opaque-access-token");
+		expect(output).not.toContain("opaque-refresh-token");
+		const result = AuthBrokerJsonOutputSchema.parse(JSON.parse(output));
+		expect(result.dryRun).toBe(true);
+		expect(result.imported).toEqual([]);
+		expect(result.skipped).toEqual([]);
+		expect(result.plan).toEqual([
+			{
+				provider: "anthropic",
+				email: null,
+				accountId: null,
+				expiresAt,
+				disabled: false,
+				file: source,
+			},
+		]);
+	});
+});
+
+describe("auth-broker login", () => {
+	it("dry-runs Anthropic Console remote login without a localhost tunnel", async () => {
+		const stdout: string[] = [];
+
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			stdout.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+			return true;
+		});
+
+		await runAuthBrokerCommand({
+			action: "login",
+			flags: { provider: "anthropic", via: "user@broker", console: true, dryRun: true },
+		});
+
+		expect(stdout.join("").trim()).toBe("ssh user@broker 'omh auth-broker login anthropic-console'");
+	});
+
+	it("dry-runs Claude headless remote login without a localhost tunnel", async () => {
+		const stdout: string[] = [];
+
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			stdout.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+			return true;
+		});
+
+		await runAuthBrokerCommand({
+			action: "login",
+			flags: { provider: "anthropic", via: "user@broker", headless: true, dryRun: true },
+		});
+
+		expect(stdout.join("").trim()).toBe("ssh user@broker 'omh auth-broker login anthropic-code'");
+	});
+});

--- a/packages/coding-agent/src/cli/auth-broker-cli.ts
+++ b/packages/coding-agent/src/cli/auth-broker-cli.ts
@@ -37,6 +37,7 @@ import { $which, APP_NAME, getAgentDbPath, getConfigRootDir, isEnoent, logger, V
 import { setTransports as setLoggerTransports } from "@oh-my-pi/pi-utils/logger";
 import { $ } from "bun";
 import chalk from "chalk";
+import { z } from "zod/v4";
 import { resolveAuthBrokerConfig } from "../session/auth-broker-config";
 
 export type AuthBrokerAction = "serve" | "token" | "login" | "logout" | "status" | "import" | "migrate" | "list";
@@ -60,6 +61,10 @@ export interface AuthBrokerCommandArgs {
 		includeEnv?: boolean;
 		/** `migrate`: required `--from-local` source. Reserved for future sources. */
 		fromLocal?: boolean;
+		/** `login anthropic`: use Anthropic Console pasted-code flow. */
+		console?: boolean;
+		/** `login anthropic`: use Claude pasted-code flow without a localhost callback. */
+		headless?: boolean;
 	};
 }
 
@@ -177,9 +182,28 @@ async function runToken(flags: AuthBrokerCommandArgs["flags"]): Promise<void> {
 	}
 }
 
+function resolveLoginProvider(provider: string | undefined, flags: AuthBrokerCommandArgs["flags"]): string | undefined {
+	if (flags.console && flags.headless) {
+		throw new Error("Choose only one Anthropic login mode: --console or --headless.");
+	}
+	if (flags.console) {
+		if (provider !== undefined && provider !== "anthropic" && provider !== "anthropic-console") {
+			throw new Error("--console is only valid with the anthropic provider.");
+		}
+		return "anthropic-console";
+	}
+	if (flags.headless) {
+		if (provider !== undefined && provider !== "anthropic" && provider !== "anthropic-code") {
+			throw new Error("--headless is only valid with the anthropic provider.");
+		}
+		return "anthropic-code";
+	}
+	return provider;
+}
+
 async function runLogin(flags: AuthBrokerCommandArgs["flags"]): Promise<void> {
 	const providers = getOAuthProviders();
-	let providerArg = flags.provider;
+	let providerArg = resolveLoginProvider(flags.provider, flags);
 	if (!providerArg) {
 		if (flags.via) {
 			throw new Error(
@@ -326,19 +350,24 @@ async function pickProviderInteractively(providers: readonly OAuthProviderInfo[]
 
 async function runRemoteLogin(provider: string, via: string, dryRun: boolean): Promise<void> {
 	const port = CALLBACK_PORTS[provider];
-	if (port === undefined) {
+	const sshArgs =
+		port === undefined
+			? PASTE_CODE_LOGIN_PROVIDERS.has(provider)
+				? [via, `${APP_NAME} auth-broker login ${provider}`]
+				: undefined
+			: [
+					"-L",
+					`${port}:127.0.0.1:${port}`,
+					"-o",
+					"ExitOnForwardFailure=yes",
+					via,
+					`${APP_NAME} auth-broker login ${provider}`,
+				];
+	if (sshArgs === undefined) {
 		throw new Error(
-			`No known OAuth callback port for '${provider}'. Use device-code flow on the broker host directly.`,
+			`No known OAuth callback port or pasted-code login flow for '${provider}'. Run login on the broker host directly.`,
 		);
 	}
-	const sshArgs = [
-		"-L",
-		`${port}:127.0.0.1:${port}`,
-		"-o",
-		"ExitOnForwardFailure=yes",
-		via,
-		`${APP_NAME} auth-broker login ${provider}`,
-	];
 	if (dryRun) {
 		process.stdout.write(`ssh ${sshArgs.map(a => (a.includes(" ") ? `'${a}'` : a)).join(" ")}\n`);
 		return;
@@ -424,17 +453,36 @@ const CLIPROXY_TYPE_TO_PROVIDER: Record<string, string> = {
 	"gemini-cli": "google-gemini-cli",
 };
 
-interface CliProxyCredentialJson {
-	type?: string;
-	access_token?: string;
-	refresh_token?: string;
-	id_token?: string;
-	expired?: string;
-	last_refresh?: string;
-	email?: string;
-	account_id?: string;
-	disabled?: boolean;
-}
+const ImportCredentialJsonSchema = z
+	.object({
+		type: z.string().optional(),
+		access_token: z.string().optional(),
+		refresh_token: z.string().optional(),
+		id_token: z.string().optional(),
+		expired: z.string().optional(),
+		last_refresh: z.string().optional(),
+		email: z.string().optional(),
+		account_id: z.string().optional(),
+		disabled: z.boolean().optional(),
+		claudeAiOauth: z
+			.object({
+				accessToken: z.string().optional(),
+				refreshToken: z.string().optional(),
+				expiresAt: z.number().optional(),
+				account: z
+					.object({
+						uuid: z.string().optional(),
+						email_address: z.string().optional(),
+					})
+					.passthrough()
+					.optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
+
+type ImportCredentialJson = z.infer<typeof ImportCredentialJsonSchema>;
 
 interface ImportPlanEntry {
 	sourceFile: string;
@@ -446,7 +494,7 @@ interface ImportPlanEntry {
 	credential: OAuthCredential;
 }
 
-function resolveCliProxyProvider(json: CliProxyCredentialJson, filename: string, overrideId?: string): string | null {
+function resolveCliProxyProvider(json: ImportCredentialJson, filename: string, overrideId?: string): string | null {
 	if (overrideId && overrideId.length > 0) return overrideId;
 	const typeField = json.type?.trim().toLowerCase();
 	if (typeField && CLIPROXY_TYPE_TO_PROVIDER[typeField]) return CLIPROXY_TYPE_TO_PROVIDER[typeField];
@@ -484,6 +532,84 @@ async function collectImportSources(target: string): Promise<string[]> {
 	return files;
 }
 
+function createImportPlanEntry(
+	file: string,
+	provider: string,
+	credential: OAuthCredential,
+	disabled: boolean,
+): ImportPlanEntry {
+	return {
+		sourceFile: file,
+		provider,
+		email: credential.email ?? null,
+		accountId: credential.accountId ?? null,
+		expiresAt: credential.expires,
+		disabled,
+		credential,
+	};
+}
+
+function parseClaudeCodeCredential(
+	json: ImportCredentialJson,
+	file: string,
+	overrideProvider: string | undefined,
+): ImportPlanEntry | string | null {
+	const oauth = json.claudeAiOauth;
+	if (!oauth) return null;
+	const provider = overrideProvider && overrideProvider.length > 0 ? overrideProvider : "anthropic";
+	if (!oauth.accessToken || !oauth.refreshToken)
+		return "missing claudeAiOauth.accessToken or claudeAiOauth.refreshToken";
+	if (typeof oauth.expiresAt !== "number" || !Number.isFinite(oauth.expiresAt)) {
+		return `cannot parse claudeAiOauth.expiresAt=${String(oauth.expiresAt ?? "?")}`;
+	}
+	const email =
+		typeof oauth.account?.email_address === "string" && oauth.account.email_address.length > 0
+			? oauth.account.email_address
+			: null;
+	const accountId =
+		typeof oauth.account?.uuid === "string" && oauth.account.uuid.length > 0 ? oauth.account.uuid : null;
+	return createImportPlanEntry(
+		file,
+		provider,
+		{
+			type: "oauth",
+			access: oauth.accessToken,
+			refresh: oauth.refreshToken,
+			expires: oauth.expiresAt,
+			...(email !== null ? { email } : {}),
+			...(accountId !== null ? { accountId } : {}),
+		},
+		json.disabled === true,
+	);
+}
+
+function parseCliProxyCredential(
+	json: ImportCredentialJson,
+	file: string,
+	overrideProvider: string | undefined,
+): ImportPlanEntry | string {
+	const provider = resolveCliProxyProvider(json, file, overrideProvider);
+	if (!provider) return `cannot determine OMH provider from type=${json.type ?? "?"} (pass --provider to override)`;
+	if (!json.access_token || !json.refresh_token) return "missing access_token or refresh_token";
+	const expiresAt = parseCliProxyExpiry(json.expired);
+	if (expiresAt === null) return `cannot parse expired=${json.expired ?? "?"}`;
+	const email = typeof json.email === "string" && json.email.length > 0 ? json.email : null;
+	const accountId = typeof json.account_id === "string" && json.account_id.length > 0 ? json.account_id : null;
+	return createImportPlanEntry(
+		file,
+		provider,
+		{
+			type: "oauth",
+			access: json.access_token,
+			refresh: json.refresh_token,
+			expires: expiresAt,
+			...(email !== null ? { email } : {}),
+			...(accountId !== null ? { accountId } : {}),
+		},
+		json.disabled === true,
+	);
+}
+
 async function loadImportPlan(
 	target: string,
 	overrideProvider: string | undefined,
@@ -493,9 +619,9 @@ async function loadImportPlan(
 	const entries: ImportPlanEntry[] = [];
 	const skipped: Array<{ file: string; reason: string }> = [];
 	for (const file of files) {
-		let json: CliProxyCredentialJson;
+		let json: ImportCredentialJson;
 		try {
-			json = (await Bun.file(file).json()) as CliProxyCredentialJson;
+			json = ImportCredentialJsonSchema.parse(await Bun.file(file).json());
 		} catch (err) {
 			skipped.push({ file, reason: `unreadable JSON: ${String(err)}` });
 			continue;
@@ -504,42 +630,14 @@ async function loadImportPlan(
 			skipped.push({ file, reason: "credential marked disabled (use --include-disabled to import anyway)" });
 			continue;
 		}
-		const provider = resolveCliProxyProvider(json, file, overrideProvider);
-		if (!provider) {
-			skipped.push({
-				file,
-				reason: `cannot determine OMH provider from type=${json.type ?? "?"} (pass --provider to override)`,
-			});
+		const parsed =
+			parseClaudeCodeCredential(json, file, overrideProvider) ??
+			parseCliProxyCredential(json, file, overrideProvider);
+		if (typeof parsed === "string") {
+			skipped.push({ file, reason: parsed });
 			continue;
 		}
-		if (!json.access_token || !json.refresh_token) {
-			skipped.push({ file, reason: "missing access_token or refresh_token" });
-			continue;
-		}
-		const expiresAt = parseCliProxyExpiry(json.expired);
-		if (expiresAt === null) {
-			skipped.push({ file, reason: `cannot parse expired=${json.expired ?? "?"}` });
-			continue;
-		}
-		const email = typeof json.email === "string" && json.email.length > 0 ? json.email : null;
-		const accountId = typeof json.account_id === "string" && json.account_id.length > 0 ? json.account_id : null;
-		const credential: OAuthCredential = {
-			type: "oauth",
-			access: json.access_token,
-			refresh: json.refresh_token,
-			expires: expiresAt,
-			...(email !== null ? { email } : {}),
-			...(accountId !== null ? { accountId } : {}),
-		};
-		entries.push({
-			sourceFile: file,
-			provider,
-			email,
-			accountId,
-			expiresAt,
-			disabled: json.disabled === true,
-			credential,
-		});
+		entries.push(parsed);
 	}
 	return { entries, skipped };
 }

--- a/packages/coding-agent/src/commands/auth-broker.ts
+++ b/packages/coding-agent/src/commands/auth-broker.ts
@@ -37,6 +37,12 @@ export default class AuthBroker extends Command {
 		provider: Flags.string({
 			description: "Override provider id for `import` (e.g. when JSON `type` is unrecognized)",
 		}),
+		console: Flags.boolean({
+			description: "Use Anthropic Console pasted-code login (login anthropic)",
+		}),
+		headless: Flags.boolean({
+			description: "Use Claude pasted-code login without a localhost callback (login anthropic)",
+		}),
 		"include-disabled": Flags.boolean({
 			description: "Import credentials whose JSON has `disabled: true` (import)",
 		}),
@@ -61,6 +67,8 @@ export default class AuthBroker extends Command {
 		`# Local login (run on the broker host)\n  ${APP_NAME} auth-broker login anthropic`,
 		`# Interactive provider selection\n  ${APP_NAME} auth-broker login`,
 		`# Remote login over SSH tunnel\n  ${APP_NAME} auth-broker login anthropic --via=user@broker`,
+		`# Anthropic Console login without a localhost callback\n  ${APP_NAME} auth-broker login anthropic --console`,
+		`# Claude subscription login without a localhost callback\n  ${APP_NAME} auth-broker login anthropic --headless`,
 		`# Log out of a provider (interactive without provider arg)\n  ${APP_NAME} auth-broker logout anthropic`,
 		`# Import a CLIProxyAPI auth dump\n  ${APP_NAME} auth-broker import ~/.cliproxy/auth`,
 		`# Import a single CLIProxyAPI JSON, overriding the provider mapping\n  ${APP_NAME} auth-broker import ~/.cliproxy/auth/claude-foo.json --provider anthropic`,
@@ -86,12 +94,14 @@ export default class AuthBroker extends Command {
 				// `login`/`logout` reuse the legacy `provider` slot; `import` keeps `source` separate
 				// so `provider` flag (used as an override) is unambiguous.
 				provider: action === "import" ? flags.provider : (args.source ?? flags.provider),
-				source: args.source,
+				source: action === "import" ? args.source : undefined,
 				includeDisabled: flags["include-disabled"],
 				fromLocal: flags["from-local"],
 				includeEnv: flags["include-env"],
 				includeOauth: flags["include-oauth"],
 				dryRun: flags["dry-run"],
+				console: flags.console,
+				headless: flags.headless,
 			},
 		};
 		await initTheme();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -644,6 +644,14 @@ export class InputController {
 
 			if (!text && !hasPendingImages) return;
 
+			if (!hasPendingImages && this.ctx.oauthManualInput?.hasPending()) {
+				this.ctx.editor.clearDraft();
+				if (this.ctx.oauthManualInput.submit(text)) {
+					this.ctx.showStatus("OAuth callback received; completing login…");
+				}
+				return;
+			}
+
 			// Continue shortcuts: "." or "c" resume the agent with a hidden agent-authored
 			// developer directive (no visible user message) instead of an empty turn, so the
 			// model continues the prior intent rather than second-guessing the interrupt.

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -79,7 +79,7 @@ import { UserMessageSelectorComponent } from "../components/user-message-selecto
 import type { SessionObserverRegistry } from "../session-observer-registry";
 import { buildCopyTargets } from "../utils/copy-targets";
 
-const MANUAL_LOGIN_TIP = "Tip: You can complete pairing with /login <redirect URL>.";
+const MANUAL_LOGIN_TIP = "Tip: Paste the code directly here, or use /login <redirect URL>.";
 
 export class SelectorController {
 	constructor(private ctx: InteractiveModeContext) {}

--- a/packages/coding-agent/test/input-controller-slash-history.test.ts
+++ b/packages/coding-agent/test/input-controller-slash-history.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "bun:test";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import { OAuthManualInputManager } from "@oh-my-pi/pi-coding-agent/modes/oauth-manual-input";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 
 // Drives the real editor submit handler through the builtin slash dispatch
@@ -11,6 +12,7 @@ import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/typ
 function makeCtx() {
 	const addToHistory = vi.fn();
 	const handleMCPCommand = vi.fn(async () => {});
+	const oauthManualInput = new OAuthManualInputManager();
 	let text = "";
 	const editor = {
 		onSubmit: undefined as undefined | ((t: string) => Promise<void>),
@@ -38,10 +40,11 @@ function makeCtx() {
 		collabGuest: undefined,
 		handleHotkeysCommand: vi.fn(),
 		handleMCPCommand,
+		oauthManualInput,
 		showStatus: vi.fn(),
 		ui: { requestRender: vi.fn() },
 	} as unknown as InteractiveModeContext;
-	return { ctx, editor, addToHistory, handleMCPCommand };
+	return { ctx, editor, addToHistory, handleMCPCommand, oauthManualInput };
 }
 
 function controllerFor(ctx: InteractiveModeContext) {
@@ -79,6 +82,18 @@ describe("input controller — slash command history (#3148)", () => {
 		// Command still executes...
 		expect(handleMCPCommand).toHaveBeenCalledWith("/mcp add srv --url http://x --token sk-secret123");
 		// ...but the secret-bearing text is kept out of recallable history.
+		expect(addToHistory).not.toHaveBeenCalled();
+	});
+
+	it("routes raw pasted OAuth codes to the pending login instead of the agent", async () => {
+		const { ctx, editor, addToHistory, oauthManualInput } = makeCtx();
+		const pending = oauthManualInput.waitForInput("anthropic-code");
+		controllerFor(ctx);
+
+		await editor.onSubmit?.("code-secret#state-secret");
+
+		expect(await pending).toBe("code-secret#state-secret");
+		expect(ctx.showStatus).toHaveBeenCalledWith("OAuth callback received; completing login…");
 		expect(addToHistory).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary
- Add Anthropic Claude subscription and Console pasted-code OAuth providers that store credentials under the existing `anthropic` provider.
- Add auth-broker `--headless` and `--console` login modes plus Claude Code `.credentials.json` import support.
- Route pasted OAuth codes in the TUI to the pending login flow before normal prompt submission.

## Verification
- `bun test packages/ai/test/anthropic-oauth.test.ts`
- `bun test packages/coding-agent/src/cli/__tests__/auth-broker-cli.test.ts`
- `bun test packages/coding-agent/test/input-controller-slash-history.test.ts`
- `bun test packages/coding-agent/test/slash-commands/login.test.ts`
- `bun test scripts/ci-release-notes.test.ts`
- `bun check`